### PR TITLE
Fix `sylius_cms_api_platform_mapping_path` parameter value

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,7 @@ imports:
 
 parameters:
     sylius.sitemap.path: "%kernel.project_dir%/var/sitemap"
-    sylius_cms_api_platform_mapping_path: 'vendor/sylius/cms-plugin/config/api_platform/'
+    sylius_cms_api_platform_mapping_path: '%kernel.project_dir%/vendor/sylius/cms-plugin/config/api_platform/'
     sylius_validation_group: [cms]
     sylius_cms.form.type.block.validation_groups: "%sylius_validation_group%"
     sylius_cms.form.type.content_configuration.validation_groups: "%sylius_validation_group%"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update UPGRADE-*.md file -->
| License         | MIT

Fixes (when used with Sylius-Standard):
```
The directory "vendor/sylius/cms-plugin/config/api_platform" does not exist in . (which is being imported from "/Users/rafik/Sylius/Sylius-Standard/config/routes/api_platform.yaml"). Make sure there is a loader supporting the "api_platform" type.
```