### PR TITLE
Pass context to the block rendering

### DIFF
--- a/templates/shop/shared/components/render/block.html.twig
+++ b/templates/shop/shared/components/render/block.html.twig
@@ -1,4 +1,5 @@
 {{ sylius_cms_render_block(
     code,
     template|default(null),
+    context|default(null),
 ) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

This configuration was ignored when rendered on the storefront:
<img width="1409" alt="image" src="https://github.com/user-attachments/assets/e40ae25e-4a15-48ac-bfd8-3d0f21525f80" />
