### PR TITLE
Fix link to Sylius documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Symfony Flex, it's much quicker!
 
 ## Documentation
 
-For more information about the plugin, please refer to the [Sylius documentation](https://docs.sylius.com/sylius-official-plugins-documentation/cms-plugin).
+For more information about the plugin, please refer to the [Sylius documentation](https://docs.sylius.com/sylius-plugins).
 
 ## Security issues
 


### PR DESCRIPTION
Sylius documentation URLs have been changed (again).

The new one leading to CMS plugin docs is a generic plugins URL (no anchor, no specification of plugin in URL path)

| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT
