### PR TITLE
Use translatable page title instead of page name

### DIFF
--- a/features/shop/displaying_page.feature
+++ b/features/shop/displaying_page.feature
@@ -14,6 +14,7 @@ Feature: Displaying pages
         And there are existing collections named "Blog" and "General"
         And this page has these collections associated with it
         And this page has "About us" name
+        And this page also has "About us" title
         And this page also has "about-us" slug
         When I go to the "about-us" page
         Then I should see a page with "About us" name

--- a/templates/shop/collection/page/index/content/body/pages/page/header.html.twig
+++ b/templates/shop/collection/page/index/content/body/pages/page/header.html.twig
@@ -1,5 +1,5 @@
 {% set page = hookable_metadata.context.page %}
 
 <a href="{{ path('sylius_cms_shop_page_show', {'slug' : page.slug}) }}">
-    <h4>{{ page.name }}</h4>
+    <h4>{{ page.title }}</h4>
 </a>

--- a/templates/shop/page/link.html.twig
+++ b/templates/shop/page/link.html.twig
@@ -6,7 +6,7 @@
         {% endfor %}
     {% endif %}
     >
-    {{ options.name|default(page.name) }}
+    {{ options.name|default(page.title) }}
     </a>
 {% else %}
     {{ options.notFoundMessage|default('') }}

--- a/templates/shop/page/show/content/body/header.html.twig
+++ b/templates/shop/page/show/content/body/header.html.twig
@@ -1,1 +1,1 @@
-<h1 class="mb-3 cms-page-name" {{ sylius_test_html_attribute('cms-page-name') }}>{{ hookable_metadata.context.page.title }}</h1>
+<h1 class="mb-3 cms-page-title" {{ sylius_test_html_attribute('cms-page-name') }}>{{ hookable_metadata.context.page.title }}</h1>

--- a/templates/shop/page/show/content/body/header.html.twig
+++ b/templates/shop/page/show/content/body/header.html.twig
@@ -1,1 +1,1 @@
-<h1 class="mb-3 cms-page-name" {{ sylius_test_html_attribute('cms-page-name') }}>{{ hookable_metadata.context.page.name }}</h1>
+<h1 class="mb-3 cms-page-name" {{ sylius_test_html_attribute('cms-page-name') }}>{{ hookable_metadata.context.page.title }}</h1>

--- a/templates/shop/page/show/content/breadcrumbs.html.twig
+++ b/templates/shop/page/show/content/breadcrumbs.html.twig
@@ -2,5 +2,5 @@
 
 {{ breadcrumbs([
     { label: 'sylius.ui.home'|trans, path: path('sylius_shop_homepage')},
-    { label:  hookable_metadata.context.page.name, active: true }
+    { label:  hookable_metadata.context.page.title, active: true }
 ]) }}


### PR DESCRIPTION
When working with this bundle on a multilingual website, I realized the page name was displayed everywhere and it's non translatable. My idea was that it should be the page title that should be used instead.

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT
