### PR TITLE
Remove sylius ^2.1 from github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,15 +29,6 @@ jobs:
                 mysql: ["8.4"]
                 postgres: ["15.8"]
 
-                include:
-                    -
-                        php: "8.3"
-                        symfony: "~7.2.0"
-                        sylius: "~2.0.0"
-                        node: "24.x"
-                        database: "mysql"
-                        mysql: "8.4"
-
         env:
             APP_ENV: test
             DATABASE_URL: ${{ matrix.database == 'mysql' && format('mysql://root:root@127.0.0.1/sylius?serverVersion={0}', matrix.mysql) || format('pgsql://postgres:postgres@127.0.0.1/sylius?serverVersion={0}', matrix.postgres) }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
             matrix:
                 php: ["8.3"]
                 symfony: ["^6.4", "~7.3.0"]
-                sylius: ["~2.0.0", "~2.1.0"]
+                sylius: ["~2.0.0"]
                 database: ["mysql", "postgres"]
                 node: ["22.x"]
                 mysql: ["8.4"]
@@ -33,7 +33,7 @@ jobs:
                     -
                         php: "8.3"
                         symfony: "~7.2.0"
-                        sylius: "~2.1.0"
+                        sylius: "~2.0.0"
                         node: "24.x"
                         database: "mysql"
                         mysql: "8.4"


### PR DESCRIPTION
I removed Sylius 2.1 from GitHub Actions due to incompatibility with the 1.0 branch. Sylius 2.1 is compatible with the 1.1 branch.

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT
