### PR TITLE
Fix download media with different locales in admin panel

### DIFF
--- a/templates/admin/media/preview/file.html.twig
+++ b/templates/admin/media/preview/file.html.twig
@@ -1,7 +1,22 @@
-<div class="col-12">
-    <label for="sylius_cms_media_path" class="form-label"> {{ 'sylius_cms.ui.preview'|trans }}</label>
-    <a class="btn" href="{{ path('sylius_cms_shop_media_download', {'code': code}) }}">
-        {{ ux_icon('tabler:download') }}
-        {{ 'sylius_cms.ui.download'|trans }}
-    </a>
-</div>
+{% set localeCode = null %}
+{% set channels = hookable_metadata.context.form.channels.vars.choices %}
+
+{% set checkedChannels = hookable_metadata.context.form.children.channels.vars.value %}
+
+{% for channel in channels %}
+    {% if localeCode == null %}
+        {% if channel.data.enabled and channel.data.code in checkedChannels %}
+            {% set localeCode = channel.data.defaultLocale.code %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+
+{% if localeCode != null %}
+    <div class="col-12">
+        <label for="sylius_cms_media_path" class="form-label"> {{ 'sylius_cms.ui.preview'|trans }}</label>
+        <a class="btn" href="{{ path('sylius_cms_shop_media_download', {'code': code, '_locale': localeCode}) }}">
+            {{ ux_icon('tabler:download') }}
+            {{ 'sylius_cms.ui.download'|trans }}
+        </a>
+    </div>
+{% endif %}


### PR DESCRIPTION
Set the proper localeCode based on the selected channel, not on the user administrator language.

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #78 
| License         | MIT
