### PR TITLE
[CI] Use BuildTestAppAction

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,19 +4,27 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
-    pull_request: ~
+        paths-ignore:
+            - "*.md"
+    pull_request:
+        paths-ignore:
+            - "*.md"
     release:
-        types: [ created ]
+        types: [created]
     schedule:
         -
-            cron: "0 1 * * 6" # Run at 1am every Saturday
+            cron: "0 1 * * *" # Run at 1am every day
     workflow_dispatch: ~
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
     tests:
         runs-on: ubuntu-latest
 
-        name: "Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }},  ${{ matrix.database == 'mysql' && format('MySQL {0}', matrix.mysql) || matrix.database == 'postgres' && format('PostgreSQL {0}', matrix.postgres) }}"
+        name: "Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ matrix.database }}"
 
         strategy:
             fail-fast: false
@@ -24,167 +32,73 @@ jobs:
                 php: ["8.3"]
                 symfony: ["^6.4", "~7.3.0"]
                 sylius: ["~2.0.0", "~2.1.0"]
-                database: ["mysql", "postgres"]
+                database: ["mysql:8.4", "mariadb:11.4", "postgres:16"]
                 node: ["22.x"]
-                mysql: ["8.4"]
-                postgres: ["15.8"]
 
         env:
             APP_ENV: test
-            DATABASE_URL: ${{ matrix.database == 'mysql' && format('mysql://root:root@127.0.0.1/sylius?serverVersion={0}', matrix.mysql) || format('pgsql://postgres:postgres@127.0.0.1/sylius?serverVersion={0}', matrix.postgres) }}
 
         steps:
             -
                 uses: actions/checkout@v4
 
             -
-                name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: "${{ matrix.php }}"
-                    extensions: intl
-                    tools: flex, symfony
-                    coverage: none
-
-            -
-                name: Setup Node
-                uses: actions/setup-node@v4
-                with:
-                    node-version: "${{ matrix.node }}"
-
-            -
-                name: Shutdown default database services
+                name: Parse database string
                 run: |
-                    sudo service mysql stop || true
-                    sudo service postgresql stop || true
+                    DB_TYPE="${DATABASE%%:*}"
+                    DB_VERSION="${DATABASE##*:}"
+                    echo "DB_TYPE=$DB_TYPE" >> $GITHUB_ENV
+                    echo "DB_VERSION=$DB_VERSION" >> $GITHUB_ENV
+
+                    if [ "$DB_TYPE" = "postgres" ]; then
+                        echo "DATABASE_URL=pgsql://postgres:postgres@127.0.0.1/sylius?serverVersion=$DB_VERSION" >> $GITHUB_ENV
+                    else
+                        echo "DATABASE_URL=mysql://root:root@127.0.0.1/sylius?serverVersion=$DB_VERSION" >> $GITHUB_ENV
+                    fi
+                env:
+                    DATABASE: ${{ matrix.database }}
 
             -
-                name: Setup MySQL
-                if: matrix.database == 'mysql'
-                uses: mirromutth/mysql-action@v1.1
+                name: Build Sylius Test Application
+                uses: SyliusLabs/BuildTestAppAction@v3.2.0
                 with:
-                    mysql version: "${{ matrix.mysql }}"
-                    mysql root password: "root"
+                    e2e_js: "yes"
+                    cache_key: "${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}"
+                    cache_restore_key: "${{ runner.os }}-php-${{ matrix.php }}-composer-"
+                    database: "${{ env.DB_TYPE }}"
+                    database_version: "${{ env.DB_VERSION }}"
+                    node_version: "${{ matrix.node }}"
+                    php_version: "${{ matrix.php }}"
+                    sylius_version: "${{ matrix.sylius }}"
+                    symfony_version: "${{ matrix.symfony }}"
 
             -
-                name: Setup PostgreSQL
-                if: matrix.database == 'postgres'
-                uses: harmon758/postgresql-action@v1
-                with:
-                    postgresql version: "${{ matrix.postgres }}"
-                    postgresql password: "postgres"
+                name: Run security check
+                run: composer audit --abandoned=ignore
 
             -
-                name: Output PHP version for Symfony CLI
-                run: php -v | head -n 1 | awk '{ print $2 }' > .php-version
-
-            -
-                name: Install certificates
-                run: symfony server:ca:install
-
-            -
-                name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            -
-                name: Cache Composer
-                uses: actions/cache@v4
-                with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json **/composer.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-php-${{ matrix.php }}-composer-
-
-            -
-                name: Restrict Symfony version
-                if: matrix.symfony != ''
-                run: |
-                    composer global config --no-plugins allow-plugins.symfony/flex true
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^2.4"
-                    composer config extra.symfony.require "${{ matrix.symfony }}"
-
-            -
-                name: Restrict Sylius version
-                if: matrix.sylius != ''
-                run: composer require "sylius/sylius:${{ matrix.sylius }}" --no-update --no-scripts --no-interaction
-
-            -
-                name: Install PHP dependencies
-                run: composer install --no-interaction
-
-            -
-                name: Run PHPStan
-                run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+                name: Validate composer.json
+                run: composer validate --ansi --strict
 
             -
                 name: Run ECS
                 run: vendor/bin/ecs check
 
             -
-                name: Run unit tests
-                run: vendor/bin/phpunit --colors=always --testsuite=unit
-
-            -
-                name: Get Yarn cache directory
-                id: yarn-cache
-                run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-            -
-                name: Cache Yarn
-                uses: actions/cache@v4
-                with:
-                    path: ${{ steps.yarn-cache.outputs.dir }}
-                    key: ${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/package.json **/yarn.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-node-${{ matrix.node }}-yarn-
-
-            -
-                name: Install JS dependencies
-                run: (cd vendor/sylius/test-application && yarn install)
-
-            -
-                name: Prepare test application database
-                run: |
-                    vendor/bin/console doctrine:database:create -vvv
-                    vendor/bin/console doctrine:migrations:migrate -n -vvv -q
-
-            -
-                name: Validate database schema
-                run: vendor/bin/console doctrine:schema:validate
-
-            -
-                name: Prepare test application assets
-                run: |
-                    vendor/bin/console assets:install -vvv
-                    (cd vendor/sylius/test-application && yarn build)
-
-            -
-                name: Prepare test application cache
-                run: vendor/bin/console cache:warmup -vvv
-
-            -
-                name: Load fixtures in test application
-                run: vendor/bin/console sylius:fixtures:load -n
-            -
-                name: Validate composer.json
-                run: composer validate --ansi --strict
-
-            -
-                name: Validate container
+                name: Lint container
                 run: vendor/bin/console lint:container
 
             -
-                name: Run Non-unit PHPUnit tests
+                name: Run PHPStan
+                run: vendor/bin/phpstan analyse -c phpstan.neon.dist
+
+            -
+                name: Run PHPUnit (Unit)
+                run: vendor/bin/phpunit --colors=always --testsuite=unit
+
+            -
+                name: Run PHPUnit (Non-unit)
                 run: vendor/bin/phpunit --colors=always --testsuite=non-unit
-
-            -
-                name: Run Chrome Headless
-                run: google-chrome-stable --enable-automation --disable-background-networking --no-default-browser-check --no-first-run --disable-popup-blocking --disable-default-apps --allow-insecure-localhost --disable-translate --disable-extensions --no-sandbox --enable-features=Metal --headless --remote-debugging-port=9222 --window-size=2880,1800 --proxy-server='direct://' --proxy-bypass-list='*' http://127.0.0.1 > /dev/null 2>&1 &
-
-            -
-                name: Run webserver
-                run: symfony server:start --port=8080 --daemon
 
             -
                 name: Run Behat
@@ -197,7 +111,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Behat logs - ${{ matrix.sylius }}-${{ github.run_id }}-${{ github.run_number }}"
+                    name: "Behat logs - Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ matrix.database }}"
                     path: etc/build/
                     if-no-files-found: ignore
                     compression-level: 6

--- a/behat.yaml.dist
+++ b/behat.yaml.dist
@@ -13,7 +13,7 @@ default:
 
         Behat\MinkExtension:
             files_path: "%paths.base%/vendor/sylius/sylius/src/Sylius/Behat/Resources/fixtures/"
-            base_url: "https://127.0.0.1:8080/"
+            base_url: "http://127.0.0.1:8080/"
             default_session: symfony
             javascript_session: chrome
             sessions:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| Related tickets | -

Refactors `.github/workflows/build.yaml` to use `SyliusLabs/BuildTestAppAction@v3.2.0` instead of manually defining all setup steps. Also changes scheduled run from weekly to daily.

### Changes

- Uses `SyliusLabs/BuildTestAppAction@v3.2.0` for simplified CI setup
- Adds MariaDB to test matrix
- Updates database versions to currently supported releases:
  - **MySQL 8.4** (LTS, supported until April 2032)
  - **MariaDB 11.4** (LTS, supported until May 2029)
  - **PostgreSQL 16** (supported until November 2028)
- Uses `database:version` format in matrix for cleaner configuration (e.g., `mysql:8.4`, `mariadb:11.4`, `postgres:16`)

### Refs
- https://docs.sylius.com/plugins-development-guide/test-application
- https://github.com/SyliusLabs/BuildTestAppAction
- https://www.postgresql.org/support/versioning/
- https://mariadb.org/about/#maintenance-policy
- https://www.mysql.com/support/supportedplatforms/database.html