### PR TITLE
[Admin] Fix override via extra_options in autocomplete types

### DIFF
--- a/src/Form/Type/BlockAutocompleteType.php
+++ b/src/Form/Type/BlockAutocompleteType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\CmsPlugin\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
@@ -32,8 +33,12 @@ final class BlockAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->blockClass,
-            'choice_label' => 'name',
-            'choice_value' => 'code',
+            'choice_label' => function (Options $options) {
+                return $options['extra_options']['choice_label'] ?? 'name';
+            },
+            'choice_value' => function (Options $options, $previousValue) {
+                return $options['extra_options']['choice_value'] ?? $previousValue;
+            },
         ]);
     }
 

--- a/src/Form/Type/CollectionAutocompleteType.php
+++ b/src/Form/Type/CollectionAutocompleteType.php
@@ -16,6 +16,7 @@ namespace Sylius\CmsPlugin\Form\Type;
 use Sylius\CmsPlugin\Entity\CollectionInterface;
 use Sylius\CmsPlugin\Form\Normalizer\TypedQueryBuilderNormalizer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
@@ -36,8 +37,12 @@ final class CollectionAutocompleteType extends AbstractType
         $resolver->setAllowedValues('type', [null, CollectionType::BLOCK, CollectionType::MEDIA, CollectionType::PAGE]);
         $resolver->setDefaults([
             'class' => $this->collectionClass,
-            'choice_value' => 'code',
-            'choice_label' => fn (CollectionInterface $collection): string => (string) $collection->getName(),
+            'choice_label' => function (Options $options) {
+                return $options['extra_options']['choice_label'] ?? fn (CollectionInterface $collection): string => (string) $collection->getName();
+            },
+            'choice_value' => function (Options $options, $previousValue) {
+                return $options['extra_options']['choice_value'] ?? $previousValue;
+            },
         ]);
         $resolver->addNormalizer('query_builder', TypedQueryBuilderNormalizer::normalize(...));
     }

--- a/src/Form/Type/MediaAutocompleteType.php
+++ b/src/Form/Type/MediaAutocompleteType.php
@@ -16,6 +16,7 @@ namespace Sylius\CmsPlugin\Form\Type;
 use Sylius\CmsPlugin\Entity\MediaInterface;
 use Sylius\CmsPlugin\Form\Normalizer\TypedQueryBuilderNormalizer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
@@ -41,9 +42,15 @@ final class MediaAutocompleteType extends AbstractType
         ]);
         $resolver->setDefaults([
             'class' => $this->mediaClass,
-            'choice_label' => 'name',
-            'choice_value' => 'code',
-            'type' => null,
+            'choice_label' => function (Options $options) {
+                return $options['extra_options']['choice_label'] ?? 'name';
+            },
+            'choice_value' => function (Options $options, $previousValue) {
+                return $options['extra_options']['choice_value'] ?? $previousValue;
+            },
+            'type' => function (Options $options) {
+                return $options['extra_options']['type'] ?? null;
+            },
         ]);
 
         $resolver->setNormalizer('query_builder', TypedQueryBuilderNormalizer::normalize(...));

--- a/src/Form/Type/PageAutocompleteType.php
+++ b/src/Form/Type/PageAutocompleteType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\CmsPlugin\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
@@ -32,8 +33,12 @@ final class PageAutocompleteType extends AbstractType
     {
         $resolver->setDefaults([
             'class' => $this->pageClass,
-            'choice_label' => 'name',
-            'choice_value' => 'code',
+            'choice_label' => function (Options $options) {
+                return $options['extra_options']['choice_label'] ?? 'name';
+            },
+            'choice_value' => function (Options $options, $previousValue) {
+                return $options['extra_options']['choice_value'] ?? $previousValue;
+            },
         ]);
     }
 

--- a/src/Form/Type/TemplateAutocompleteType.php
+++ b/src/Form/Type/TemplateAutocompleteType.php
@@ -16,6 +16,7 @@ namespace Sylius\CmsPlugin\Form\Type;
 use Sylius\CmsPlugin\Entity\TemplateInterface;
 use Sylius\CmsPlugin\Form\Normalizer\TypedQueryBuilderNormalizer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\Autocomplete\Form\AsEntityAutocompleteField;
 use Symfony\UX\Autocomplete\Form\BaseEntityAutocompleteType;
@@ -36,8 +37,12 @@ final class TemplateAutocompleteType extends AbstractType
         $resolver->setAllowedValues('type', [null, 'page', 'block']);
         $resolver->setDefaults([
             'class' => $this->templateClass,
-            'choice_value' => 'id',
-            'choice_label' => fn (TemplateInterface $template): string => (string) $template->getName(),
+            'choice_label' => function (Options $options) {
+                return $options['extra_options']['choice_label'] ?? fn (TemplateInterface $template): string => (string) $template->getName();
+            },
+            'choice_value' => function (Options $options, $previousValue) {
+                return $options['extra_options']['choice_value'] ?? $previousValue;
+            },
         ]);
         $resolver->setNormalizer('query_builder', TypedQueryBuilderNormalizer::normalize(...));
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

  ## Summary
  - Allow overriding `choice_label` and `choice_value` via `extra_options`