### PR TITLE
Use SyliusLabs/UpmergeAction for upmerge workflow

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -31,33 +31,8 @@ jobs:
                     ref: ${{ matrix.target_branch }}
 
             -
-                name: Reset upmerge branch
-                run: |
-                    git fetch origin ${{ matrix.base_branch }}:${{ matrix.base_branch }}
-                    git reset --hard ${{ matrix.base_branch }}
-
-            -
-                name: Create Pull Request
-                uses: peter-evans/create-pull-request@v4
+                uses: SyliusLabs/UpmergeAction@v1
                 with:
+                    base_branch: ${{ matrix.base_branch }}
+                    target_branch: ${{ matrix.target_branch }}
                     token: ${{ secrets.SYLIUS_BOT_PAT }}
-                    title: '[UPMERGE] ${{ matrix.base_branch }} -> ${{ matrix.target_branch }}'
-                    body: |
-                        This PR has been generated automatically.
-                        For more details see [upmerge_pr.yaml](/Sylius/CmsPlugin/blob/1.0/.github/workflows/upmerge_pr.yaml).
-                        
-                        **Remember!** The upmerge should always be merged with using `Merge pull request` button.
-                        
-                        In case of conflicts, please resolve them manually with using the following commands:
-                        ```
-                        git fetch upstream
-                        gh pr checkout <this-pr-number>
-                        git merge upstream/${{ matrix.target_branch }} -m "Resolve conflicts between ${{ matrix.base_branch }} and ${{ matrix.target_branch }}"
-                        ```
-                        
-                        If you use other name for the upstream remote, please replace `upstream` with the name of your remote pointing to the `Sylius/CmsPlugin` repository.
-                        
-                        Once the conflicts are resolved, please run `git merge --continue` and push the changes to this PR.
-                    branch: "upmerge/${{ matrix.base_branch }}_${{ matrix.target_branch }}"
-                    delete-branch: true
-                    base: ${{ matrix.target_branch }}


### PR DESCRIPTION
Replaces inline upmerge logic with the new reusable SyliusLabs/UpmergeAction.

Fixes the issue where the workflow fails when there are no commits to upmerge (target branch already up to date).