### PR TITLE
Allow custom branch inputs for manual upmerge workflow

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -4,16 +4,26 @@ on:
     schedule:
         -
             cron: "0 2 * * *"
-    workflow_dispatch: ~
+    workflow_dispatch:
+        inputs:
+            base_branch:
+                description: "Source branch (leave empty for default matrix)"
+                required: false
+                type: string
+            target_branch:
+                description: "Target branch (leave empty for default matrix)"
+                required: false
+                type: string
 
 permissions:
     contents: write
     pull-requests: write
 
 jobs:
-    upmerge:
+    # Scheduled runs or manual without inputs - use matrix
+    upmerge-matrix:
+        if: github.repository == 'Sylius/CmsPlugin' && !inputs.base_branch
         runs-on: ubuntu-latest
-        if: github.repository == 'Sylius/CmsPlugin'
         name: "Upmerge PR"
         timeout-minutes: 5
         strategy:
@@ -35,4 +45,24 @@ jobs:
                 with:
                     base_branch: ${{ matrix.base_branch }}
                     target_branch: ${{ matrix.target_branch }}
+                    token: ${{ secrets.SYLIUS_BOT_PAT }}
+
+    # Manual with custom inputs
+    upmerge-custom:
+        if: github.repository == 'Sylius/CmsPlugin' && inputs.base_branch
+        runs-on: ubuntu-latest
+        name: "Upmerge PR (${{ inputs.base_branch }} -> ${{ inputs.target_branch }})"
+        timeout-minutes: 5
+
+        steps:
+            -
+                uses: actions/checkout@v4
+                with:
+                    ref: ${{ inputs.target_branch }}
+
+            -
+                uses: SyliusLabs/UpmergeAction@v1
+                with:
+                    base_branch: ${{ inputs.base_branch }}
+                    target_branch: ${{ inputs.target_branch }}
                     token: ${{ secrets.SYLIUS_BOT_PAT }}


### PR DESCRIPTION
Adds optional inputs to workflow_dispatch allowing manual upmerge between any branches.

Usage via CLI:
```bash
gh workflow run upmerge_pr.yaml -f base_branch=hotfix-123 -f target_branch=1.1
```

Empty inputs = default matrix (1.0 → 1.1).