### PR TITLE
Fix template resource config filename and item uriTemplate

### DIFF
--- a/config/api_platform/resources/shop/Template.xml
+++ b/config/api_platform/resources/shop/Template.xml
@@ -37,7 +37,7 @@
             <operation
                 name="sylius_cms_api_shop_template_get"
                 class="ApiPlatform\Metadata\Get"
-                uriTemplate="/shop/cms/template/{id}"
+                uriTemplate="/shop/cms/templates/{id}"
             >
                 <normalizationContext>
                     <values>


### PR DESCRIPTION
## [BC] Rename Template resource config file and unify shop template item URI

### Description

This PR introduces two changes to the CMS Template shop API resource configuration:

1. Renames the incorrectly named file:
   - `Tempalate.xml` → `Template.xml`

2. Updates the item operation `uriTemplate` from:
   - `/shop/cms/template/{id}`
   to:
   - `/shop/cms/templates/{id}`

The goal is to align the item endpoint with the collection endpoint:

- Collection: `/shop/cms/templates`
- Item (after change): `/shop/cms/templates/{id}`

### Rationale

- The filename currently contains a typo.
- The item endpoint uses a singular form (`template`) while the collection uses a plural form (`templates`).
- This change makes the API structure consistent and predictable.

### ⚠️ Backward Compatibility

This change modifies a public API endpoint:
/shop/cms/template/{id}

is replaced by:
/shop/cms/templates/{id}

If the singular endpoint is already used in production integrations, this constitutes a **backward compatibility break**.

Please advise whether:
- This should target a major version only, or
- A deprecation path should be introduced instead.

### How to verify

1. Install CmsPlugin in a Sylius project.
2. Clear cache.
3. Run:
bin/console debug:router | grep cms

Expected output includes:
/shop/cms/templates
/shop/cms/templates/{id}


4. Ensure API Platform metadata loads without errors.

### Checklist

- [x] XML is valid
- [x] No duplicate route definitions
- [x] Follows API Platform metadata structure
- [x] BC impact documented