### PR TITLE
Restore editor content after adding content blocks

### DIFF
--- a/assets/admin/js/trix/trix-editor.js
+++ b/assets/admin/js/trix/trix-editor.js
@@ -62,6 +62,34 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+document.querySelectorAll('select').forEach(select => {
+    select.addEventListener('change', (event) => {
+        document.querySelectorAll('trix-editor').forEach((editor) => {
+            const innerInput = document.getElementById(editor.attributes.input.value);
+
+            if (innerInput) {
+                editor.innerHTML = innerInput.value;
+            }
+        });
+
+        updateToolbars();
+    });
+});
+
+document.querySelectorAll('button[data-live-action-param="addCollectionItem"]').forEach(button => {
+    button.addEventListener('click', (event) => {
+        document.querySelectorAll('trix-editor').forEach((editor) => {
+            const innerInput = document.getElementById(editor.attributes.input.value);
+            
+            if (innerInput) {
+                editor.innerHTML = innerInput.value;
+            }
+        });
+
+        updateToolbars();
+    });
+});
+
 function updateToolbars() {
     const toolbars = document.querySelectorAll('trix-toolbar');
     const html = removeToolbarFileTools(Trix.config.toolbar.getDefaultHTML());


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #144, initial fix in #104, was removed in commit 20c9eba
| License         | MIT

Commit 20c9eba added `DOMContentLoaded` as a listener instead which does not account for live DOM updates after the live component is updated.