### PR TITLE
Remove cms page link classe

### DIFF
--- a/templates/shop/page/link.html.twig
+++ b/templates/shop/page/link.html.twig
@@ -1,5 +1,5 @@
 {% if page != null %}
-    <a class="cms-page-link" href="{{ path('sylius_cms_shop_page_show', { slug: page.slug }) }}"
+    <a {{ sylius_test_html_attribute('cms-page-link') }} href="{{ path('sylius_cms_shop_page_show', { slug: page.slug }) }}"
     {% if options.attr is defined %}
         {% for attrname, attrvalue in options.attr %}
             {{ attrname }}="{{ attrvalue }}"

--- a/templates/shop/page/link.html.twig
+++ b/templates/shop/page/link.html.twig
@@ -1,10 +1,11 @@
 {% if page != null %}
-    <a {{ sylius_test_html_attribute('cms-page-link') }} href="{{ path('sylius_cms_shop_page_show', { slug: page.slug }) }}"
+    <a href="{{ path('sylius_cms_shop_page_show', { slug: page.slug }) }}"
     {% if options.attr is defined %}
         {% for attrname, attrvalue in options.attr %}
             {{ attrname }}="{{ attrvalue }}"
         {% endfor %}
     {% endif %}
+    {{ sylius_test_html_attribute('cms-page-link') }}
     >
     {{ options.name|default(page.title) }}
     </a>

--- a/tests/Behat/Page/Shop/Page/ShowPage.php
+++ b/tests/Behat/Page/Shop/Page/ShowPage.php
@@ -87,7 +87,7 @@ final class ShowPage extends SymfonyPage implements ShowPageInterface
             'collections' => '[data-test-cms-page-collections]',
             'content' => '.cms-page-content',
             'custom-layout' => '.custom-layout',
-            'link' => '.cms-page-link',
+            'link' => '[data-test-cms-page-link]',
             'name' => '[data-test-cms-page-name]',
             'page-image' => '.page-image',
             'products' => '.cms-page-products',


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #149
| License         | MIT

## Summary

Replace the hardcoded `class="cms-page-link"` attribute in the CMS page link template with the Sylius `sylius_test_html_attribute()` Twig helper, and update the corresponding Behat selector.

## Changes

- **`templates/shop/page/link.html.twig`**: Replace `class="cms-page-link"` with `{{ sylius_test_html_attribute('cms-page-link') }}`.
- **`tests/Behat/Page/Shop/Page/ShowPage.php`**: Update the `link` element selector from `.cms-page-link` to `[data-test-cms-page-link]`.