### PR TITLE
FIX: #152 add required false option to collections field in PageType

### DIFF
--- a/src/Form/Type/PageType.php
+++ b/src/Form/Type/PageType.php
@@ -61,6 +61,7 @@ final class PageType extends AbstractResourceType
                 'label' => 'sylius_cms.ui.collections',
                 'multiple' => true,
                 'by_reference' => false,
+                'required' => false,
             ])
             ->add('channels', ChannelChoiceType::class, [
                 'label' => 'sylius_cms.ui.channels',


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #152 
| License         | MIT

When creating a page the collections field is marked as required currently. However, as there is no validation behind that, you can still creating a page without select a collection. But as choosing a collection is optional (same as when creating a block, or media) the `collections` field in the `PageType` class should be set to `required = false`.