### PR TITLE
FIX: [Shop] #115 fix slug route requirement to support nested page slugs

### DIFF
--- a/config/routes/shop/page.yaml
+++ b/config/routes/shop/page.yaml
@@ -3,6 +3,8 @@ sylius_cms_shop_page_show:
     methods: [GET]
     defaults:
         _controller: sylius_cms.controller.page.overriden::showAction
+    requirements:
+        slug: .+(?<!/)
 
 sylius_cms_shop_collections_page_index:
     path: /collections/{code}/pages

--- a/features/shop/displaying_page.feature
+++ b/features/shop/displaying_page.feature
@@ -38,3 +38,12 @@ Feature: Displaying pages
         And this page also has "title" slug
         When I go to this page
         Then I should see page title "United States"
+
+    @ui
+    Scenario: Displaying page with a nested slug containing a slash
+        Given there is a page in the store
+        And this page has "Article one" name
+        And this page also has "Article one" title
+        And this page also has "articles/article1" slug
+        When I go to the "articles/article1" page
+        Then I should see a page with "Article one" name


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #115 
| License         | MIT

**Description**

When you have for example a rendered page link in the collections, and the page link slug has two `/` in the slug, it currently crashes and returns a exception.

<img width="1035" height="600" alt="image" src="https://github.com/user-attachments/assets/7e6132de-dd60-4613-b1c6-be6235c23c51" />

This is because, the `sylius_cms_shop_page_show` route in the `config/routes/page.yaml` has no requirements for the `{slug}` defined. And therefore, it uses the default config by Symfony `[^/]++`. And this does not allow two `/`.