### PR TITLE
FEAT: [Admin] #100 add functionality to add new content elements between existing ones

### DIFF
--- a/features/admin/page/inserting_content_elements_on_page.feature
+++ b/features/admin/page/inserting_content_elements_on_page.feature
@@ -10,7 +10,7 @@ Feature: Inserting content elements between existing elements on a page
 
     @ui @javascript
     Scenario: Inserting a content element between two existing elements
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "insert-test-page"
         And I fill the name with "Insert Test Page"
         And I fill the slug with "insert-test-page"
@@ -23,7 +23,7 @@ Feature: Inserting content elements between existing elements on a page
 
     @ui @javascript
     Scenario: Inserting a content element before the first element
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "insert-test-page"
         And I fill the name with "Insert Test Page"
         And I fill the slug with "insert-test-page"

--- a/features/admin/page/inserting_content_elements_on_page.feature
+++ b/features/admin/page/inserting_content_elements_on_page.feature
@@ -1,0 +1,35 @@
+@managing_pages
+Feature: Inserting content elements between existing elements on a page
+    In order to manage the structure of content on a page
+    As an Administrator
+    I want to be able to insert content elements between existing ones
+
+    Background:
+        Given I am logged in as an administrator
+        And the store operates on a single channel in "United States"
+
+    @ui @javascript
+    Scenario: Inserting a content element between two existing elements
+        When I go to the create page page
+        And I fill the code with "insert-test-page"
+        And I fill the name with "Insert Test Page"
+        And I fill the slug with "insert-test-page"
+        And I add a heading content element with type "h1" and "My Title" content
+        And I add a textarea content element with "My body text" content
+        When I insert a textarea content element after the 1st content element
+        Then the 1st content element should be a "Heading" element
+        And the 2nd content element should be a "Textarea" element
+        And the 3rd content element should be a "Textarea" element
+
+    @ui @javascript
+    Scenario: Inserting a content element before the first element
+        When I go to the create page page
+        And I fill the code with "insert-test-page"
+        And I fill the name with "Insert Test Page"
+        And I fill the slug with "insert-test-page"
+        And I add a heading content element with type "h1" and "My Title" content
+        And I add a textarea content element with "My body text" content
+        When I insert a textarea content element before the 1st content element
+        Then the 1st content element should be a "Textarea" element
+        And the 2nd content element should be a "Heading" element
+        And the 3rd content element should be a "Textarea" element

--- a/features/admin/page/sorting_content_elements_on_page.feature
+++ b/features/admin/page/sorting_content_elements_on_page.feature
@@ -110,3 +110,40 @@ Feature: Sorting content elements on a page
         And I move the 2nd content element up
         Then the 1st content element should contain "Second content"
         And the 2nd content element should contain "First content"
+
+    @ui @javascript
+    Scenario: Moving a content element down moves it one position only
+        Given there is a page in the store with textarea content elements with "First content", "Second content" and "Third content" content
+        When I want to edit this page
+        And I move the 1st content element down
+        Then the 1st content element should contain "Second content"
+        And the 2nd content element should contain "First content"
+        And the 3rd content element should contain "Third content"
+
+    @ui @javascript
+    Scenario: Moving a content element up moves it one position only
+        Given there is a page in the store with textarea content elements with "First content", "Second content" and "Third content" content
+        When I want to edit this page
+        And I move the 3rd content element up
+        Then the 1st content element should contain "First content"
+        And the 2nd content element should contain "Third content"
+        And the 3rd content element should contain "Second content"
+
+    @ui @javascript
+    Scenario: Moving the same content element down repeatedly
+        Given there is a page in the store with textarea content elements with "First content", "Second content" and "Third content" content
+        When I want to edit this page
+        And I move the 1st content element down
+        And I move the 2nd content element down
+        Then the 1st content element should contain "Second content"
+        And the 2nd content element should contain "Third content"
+        And the 3rd content element should contain "First content"
+
+    @ui @javascript
+    Scenario: Moving a content element after inserting a new one in between
+        Given there is a page in the store with a textarea content element with "First content" content and a textarea content element with "Second content" content
+        When I want to edit this page
+        And I insert a textarea content element after the 1st content element
+        And I move the 3rd content element up
+        Then the 1st content element should contain "First content"
+        And the 2nd content element should contain "Second content"

--- a/features/admin/page/sorting_content_elements_on_page.feature
+++ b/features/admin/page/sorting_content_elements_on_page.feature
@@ -78,3 +78,35 @@ Feature: Sorting content elements on a page
         And I add a heading content element with type "h1" and "My Title" content
         And I add a textarea content element with "My body text" content
         Then the move down button of the 2nd content element should be disabled
+
+    @ui @javascript
+    Scenario: Moving a content element down keeps its content when editing an existing page
+        Given there is a page in the store with a textarea content element with "First content" content and a textarea content element with "Second content" content
+        When I want to edit this page
+        And I move the 1st content element down
+        Then the 1st content element should contain "Second content"
+        And the 2nd content element should contain "First content"
+
+    @ui @javascript
+    Scenario: Moving a content element up keeps its content when editing an existing page
+        Given there is a page in the store with a textarea content element with "First content" content and a textarea content element with "Second content" content
+        When I want to edit this page
+        And I move the 2nd content element up
+        Then the 1st content element should contain "Second content"
+        And the 2nd content element should contain "First content"
+
+    @ui @javascript @quill
+    Scenario: Moving a content element down keeps its content with the Quill editor
+        Given there is a page in the store with a textarea content element with "First content" content and a textarea content element with "Second content" content
+        When I want to edit this page
+        And I move the 1st content element down
+        Then the 1st content element should contain "Second content"
+        And the 2nd content element should contain "First content"
+
+    @ui @javascript @quill
+    Scenario: Moving a content element up keeps its content with the Quill editor
+        Given there is a page in the store with a textarea content element with "First content" content and a textarea content element with "Second content" content
+        When I want to edit this page
+        And I move the 2nd content element up
+        Then the 1st content element should contain "Second content"
+        And the 2nd content element should contain "First content"

--- a/src/Form/Strategy/Wysiwyg/QuillStrategy.php
+++ b/src/Form/Strategy/Wysiwyg/QuillStrategy.php
@@ -16,6 +16,8 @@ namespace Sylius\CmsPlugin\Form\Strategy\Wysiwyg;
 use Ehyiah\QuillJsBundle\DTO\Modules\FullScreenModule;
 use Ehyiah\QuillJsBundle\DTO\QuillGroup;
 use Ehyiah\QuillJsBundle\Form\QuillType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class QuillStrategy extends AbstractWysiwygStrategy
@@ -30,13 +32,20 @@ final class QuillStrategy extends AbstractWysiwygStrategy
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'quill_options' => QuillGroup::buildWithAllFields(),
-            'attr' => [
-                'data-model' => 'norender|*',
-            ],
             'modules' => [
                 new FullScreenModule(),
             ],
         ]);
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        parent::buildView($view, $form, $options);
+        // data-model="norender|*" doesn't work on individual elements — Live Component
+        // treats "*" as a literal model name instead of substituting the field's name
+        // attribute. Use the actual full_name so the Quill content is included in the
+        // component's formValues when a LiveAction (e.g. moveCollectionItem) fires.
+        $view->vars['attr']['data-model'] = 'norender|' . $view->vars['full_name'];
     }
 
     public function getBlockPrefix(): string

--- a/src/Twig/Component/Trait/ContentElementsCollectionFormComponentTrait.php
+++ b/src/Twig/Component/Trait/ContentElementsCollectionFormComponentTrait.php
@@ -70,16 +70,6 @@ trait ContentElementsCollectionFormComponentTrait
             return;
         }
 
-        // Swap the two values while both rows keep their original keys. Handing a moved row
-        // a fresh key makes it look like a brand new element to Symfony's CollectionType,
-        // which only ever appends unknown keys at the end of its children (see the note in
-        // insertCollectionItem) - the row would jump to the bottom of the collection instead
-        // of moving one position, and every following move would work on an order that no
-        // longer matches what is rendered. Keeping the keys is safe for the stateful WYSIWYG
-        // widgets because ContentElementConfigurationType puts a signature of the element's
-        // content into the configuration container's DOM id: when the content at a position
-        // changes, so does that id, and the Live Component replaces the whole subtree instead
-        // of morphing the widget in place.
         $swapKey = $keys[$swapPos];
         [$data[$index], $data[$swapKey]] = [$data[$swapKey], $data[$index]];
 
@@ -135,14 +125,6 @@ trait ContentElementsCollectionFormComponentTrait
 
         array_splice($items, $insertPosition, 0, [$newItem]);
 
-        // Symfony's CollectionType (via ResizeFormListener) never reorders existing form
-        // children - it only appends keys it doesn't have yet, always at the end of its
-        // internal list, no matter where that key sits in the submitted array. Giving only
-        // the new row a fresh key therefore isn't enough to place it mid-collection: the
-        // form would still render it last. Every row from the insertion point onward must
-        // look "new" too, so Symfony drops and re-appends that whole tail in one pass, in
-        // the order we submit it - landing it right after the untouched prefix. Rows
-        // strictly before the insertion point keep their original key/DOM node untouched.
         $freshKeysNeeded = \count($items) - $insertPosition;
         $nextKey = $this->provideNewCollectionItemIndex($data);
 

--- a/src/Twig/Component/Trait/ContentElementsCollectionFormComponentTrait.php
+++ b/src/Twig/Component/Trait/ContentElementsCollectionFormComponentTrait.php
@@ -70,28 +70,20 @@ trait ContentElementsCollectionFormComponentTrait
             return;
         }
 
-        $items = array_values($data);
-        [$items[$currentPos], $items[$swapPos]] = [$items[$swapPos], $items[$currentPos]];
+        // Swap the two values while both rows keep their original keys. Handing a moved row
+        // a fresh key makes it look like a brand new element to Symfony's CollectionType,
+        // which only ever appends unknown keys at the end of its children (see the note in
+        // insertCollectionItem) - the row would jump to the bottom of the collection instead
+        // of moving one position, and every following move would work on an order that no
+        // longer matches what is rendered. Keeping the keys is safe for the stateful WYSIWYG
+        // widgets because ContentElementConfigurationType puts a signature of the element's
+        // content into the configuration container's DOM id: when the content at a position
+        // changes, so does that id, and the Live Component replaces the whole subtree instead
+        // of morphing the widget in place.
+        $swapKey = $keys[$swapPos];
+        [$data[$index], $data[$swapKey]] = [$data[$swapKey], $data[$index]];
 
-        // Give fresh keys to the two moved rows only, while keeping the visual (insertion)
-        // order. New keys mean new DOM ids, so the Live Component re-creates exactly those
-        // two rows instead of patching them in place. This keeps stateful WYSIWYG widgets
-        // correct regardless of their morphing strategy: Trix opts out of morphing via
-        // "data-live-ignore", while Quill builds its own DOM the server never renders - in
-        // both cases an in-place patch would leave stale or corrupted content. Re-creating
-        // the row triggers the editor's disconnect()/connect() cycle, which is the path it
-        // is built to support. Untouched rows keep their keys (and initialized editors).
-        $keys = array_keys($data);
-        $freshIndex = $this->provideNewCollectionItemIndex($data);
-        $keys[$currentPos] = $freshIndex;
-        $keys[$swapPos] = $freshIndex + 1;
-
-        $reordered = [];
-        foreach ($items as $position => $item) {
-            $reordered[$keys[$position]] = $item;
-        }
-
-        $propertyAccessor->setValue($this->formValues, $propertyPath, $reordered);
+        $propertyAccessor->setValue($this->formValues, $propertyPath, $data);
     }
 
     #[LiveAction]

--- a/src/Twig/Component/Trait/ContentElementsCollectionFormComponentTrait.php
+++ b/src/Twig/Component/Trait/ContentElementsCollectionFormComponentTrait.php
@@ -70,10 +70,28 @@ trait ContentElementsCollectionFormComponentTrait
             return;
         }
 
-        $swapKey = $keys[$swapPos];
-        [$data[$index], $data[$swapKey]] = [$data[$swapKey], $data[$index]];
+        $items = array_values($data);
+        [$items[$currentPos], $items[$swapPos]] = [$items[$swapPos], $items[$currentPos]];
 
-        $propertyAccessor->setValue($this->formValues, $propertyPath, $data);
+        // Give fresh keys to the two moved rows only, while keeping the visual (insertion)
+        // order. New keys mean new DOM ids, so the Live Component re-creates exactly those
+        // two rows instead of patching them in place. This keeps stateful WYSIWYG widgets
+        // correct regardless of their morphing strategy: Trix opts out of morphing via
+        // "data-live-ignore", while Quill builds its own DOM the server never renders - in
+        // both cases an in-place patch would leave stale or corrupted content. Re-creating
+        // the row triggers the editor's disconnect()/connect() cycle, which is the path it
+        // is built to support. Untouched rows keep their keys (and initialized editors).
+        $keys = array_keys($data);
+        $freshIndex = $this->provideNewCollectionItemIndex($data);
+        $keys[$currentPos] = $freshIndex;
+        $keys[$swapPos] = $freshIndex + 1;
+
+        $reordered = [];
+        foreach ($items as $position => $item) {
+            $reordered[$keys[$position]] = $item;
+        }
+
+        $propertyAccessor->setValue($this->formValues, $propertyPath, $reordered);
     }
 
     #[LiveAction]
@@ -86,6 +104,62 @@ trait ContentElementsCollectionFormComponentTrait
         }
 
         $this->populateElements($localeCode, $template);
+    }
+
+    #[LiveAction]
+    public function insertCollectionItem(
+        PropertyAccessorInterface $propertyAccessor,
+        #[LiveArg]
+        string $name,
+        #[LiveArg]
+        ?string $type = null,
+        #[LiveArg]
+        ?int $insertAfterIndex = null,
+    ): void {
+        if (null === $this->formName) {
+            return;
+        }
+
+        $propertyPath = $this->fieldNameToPropertyPath($name, $this->formName);
+        $data = $propertyAccessor->getValue($this->formValues, $propertyPath);
+
+        if (!\is_array($data)) {
+            $data = [];
+        }
+
+        $newItem = null === $type ? [] : ['type' => $type];
+
+        $keys = array_keys($data);
+        $items = array_values($data);
+
+        if (null === $insertAfterIndex) {
+            $insertPosition = \count($items);
+        } elseif ($insertAfterIndex < 0) {
+            $insertPosition = 0;
+        } else {
+            $pos = array_search($insertAfterIndex, $keys, true);
+            $insertPosition = false !== $pos ? $pos + 1 : \count($items);
+        }
+
+        array_splice($items, $insertPosition, 0, [$newItem]);
+
+        // Symfony's CollectionType (via ResizeFormListener) never reorders existing form
+        // children - it only appends keys it doesn't have yet, always at the end of its
+        // internal list, no matter where that key sits in the submitted array. Giving only
+        // the new row a fresh key therefore isn't enough to place it mid-collection: the
+        // form would still render it last. Every row from the insertion point onward must
+        // look "new" too, so Symfony drops and re-appends that whole tail in one pass, in
+        // the order we submit it - landing it right after the untouched prefix. Rows
+        // strictly before the insertion point keep their original key/DOM node untouched.
+        $freshKeysNeeded = \count($items) - $insertPosition;
+        $nextKey = $this->provideNewCollectionItemIndex($data);
+
+        $keys = array_slice($keys, 0, $insertPosition);
+        for ($i = 0; $i < $freshKeysNeeded; ++$i) {
+            $keys[] = $nextKey + $i;
+        }
+
+        $propertyAccessor->setValue($this->formValues, $propertyPath, array_combine($keys, $items));
     }
 
     /** @param TemplateRepositoryInterface<TemplateInterface> $templateRepository */

--- a/templates/admin/macros/insert_element_divider.html.twig
+++ b/templates/admin/macros/insert_element_divider.html.twig
@@ -1,0 +1,21 @@
+{% macro insert_element_divider(collection_types, collection_name, insert_after_index) %}
+    <div class="d-flex align-items-center gap-1 my-2 px-2" {{ sylius_test_html_attribute('insert-element-divider') }}>
+        <hr class="flex-grow-1 m-0 border-secondary-subtle opacity-100">
+        <div class="dropdown">
+            <button class="btn btn-sm btn-outline-primary p-2" type="button" data-bs-toggle="dropdown">
+                {{ 'sylius_cms.ui.add_element'|trans }}
+                {{ ux_icon('tabler:chevron-down', {style: 'display: block; margin:auto;'}) }}
+            </button>
+            <ul class="dropdown-menu">
+                {%- for type, typeLabel in collection_types -%}
+                    <li>
+                        <button class="dropdown-item" type="button" data-action="live#action" data-live-action-param="insertCollectionItem" data-live-name-param="{{ collection_name }}" data-live-type-param="{{ type }}" data-live-insert-after-index-param="{{ insert_after_index }}" {{ sylius_test_html_attribute('insert-' ~ type) }}>
+                            {{ typeLabel|trans }}
+                        </button>
+                    </li>
+                {%- endfor -%}
+            </ul>
+        </div>
+        <hr class="flex-grow-1 m-0 border-secondary-subtle opacity-100">
+    </div>
+{% endmacro %}

--- a/templates/admin/shared/component_elements/form_theme.html.twig
+++ b/templates/admin/shared/component_elements/form_theme.html.twig
@@ -1,7 +1,24 @@
 {% extends '@SyliusAdmin/shared/form_theme.html.twig' %}
 
 {%- block live_collection_widget -%}
-    {{ block('form_widget') }}
+    {%- import '@SyliusCmsPlugin/admin/macros/insert_element_divider.html.twig' as InsertElementButton -%}
+
+    {%- set collection_types = button_add is defined ? button_add.vars.types : {} -%}
+    {%- set collection_name = button_add is defined ? button_add.vars.attr['data-live-name-param'] : '' -%}
+
+    <div>
+        {%- for child in form -%}
+            {%- if loop.first and collection_types is not empty -%}
+                {{ InsertElementButton.insert_element_divider(collection_types, collection_name, -1) }}
+            {%- endif -%}
+
+            {{ form_row(child) }}
+
+            {%- if not loop.last and collection_types is not empty -%}
+                {{ InsertElementButton.insert_element_divider(collection_types, collection_name, child.vars.name) }}
+            {%- endif -%}
+        {%- endfor -%}
+    </div>
 {%- endblock live_collection_widget -%}
 
 {%- block live_collection_entry_row -%}
@@ -57,12 +74,17 @@
 
 {% block add_button_row %}
     {% if types is not empty %}
-        <div class="dropdown" data-bs-toggle="dropdown" {{ sylius_test_html_attribute('add-element-button') }}>
-            <button class="btn dropdown-toggle" type="button">{{ label|trans }}</button>
+        <div class="dropdown" {{ sylius_test_html_attribute('add-element-button') }}>
+            <button class="btn dropdown-toggle" type="button" data-bs-toggle="dropdown">{{ label|trans }}</button>
             <ul class="dropdown-menu">
                 {% for type, label in types %}
                     <li>
-                        <button class="dropdown-item" type="button" {{ block('button_attributes') }} data-live-type-param="{{ type }}" {{ sylius_test_html_attribute('add-' ~ type) }}>
+                        <button class="dropdown-item" type="button"
+                            data-action="live#action"
+                            data-live-action-param="insertCollectionItem"
+                            data-live-name-param="{{ attr['data-live-name-param'] }}"
+                            data-live-type-param="{{ type }}"
+                            {{ sylius_test_html_attribute('add-' ~ type) }}>
                             {{ (label)|trans }}
                         </button>
                     </li>

--- a/tests/Behat/Context/Setup/PageContext.php
+++ b/tests/Behat/Context/Setup/PageContext.php
@@ -79,6 +79,27 @@ final class PageContext implements Context
     }
 
     /**
+     * @Given there is a page in the store with a textarea content element with :firstContent content and a textarea content element with :secondContent content
+     */
+    public function thereIsAPageInTheStoreWithTwoTextareaContentElements(string $firstContent, string $secondContent): void
+    {
+        $page = $this->createPage();
+
+        foreach ([$firstContent, $secondContent] as $content) {
+            /** @var ContentConfigurationInterface $contentConfiguration */
+            $contentConfiguration = new ContentConfiguration();
+            $contentConfiguration->setType('textarea');
+            $contentConfiguration->setLocale('en_US');
+            $contentConfiguration->setConfiguration(['textarea' => $content]);
+            $contentConfiguration->setPage($page);
+
+            $page->addContentElement($contentConfiguration);
+        }
+
+        $this->savePage($page);
+    }
+
+    /**
      * @Given there is an existing page with :name name
      */
     public function thereIsAPageWithName(string $name): void

--- a/tests/Behat/Context/Setup/PageContext.php
+++ b/tests/Behat/Context/Setup/PageContext.php
@@ -80,12 +80,13 @@ final class PageContext implements Context
 
     /**
      * @Given there is a page in the store with a textarea content element with :firstContent content and a textarea content element with :secondContent content
+     * @Given there is a page in the store with textarea content elements with :firstContent, :secondContent and :thirdContent content
      */
-    public function thereIsAPageInTheStoreWithTwoTextareaContentElements(string $firstContent, string $secondContent): void
+    public function thereIsAPageInTheStoreWithTextareaContentElements(string ...$contents): void
     {
         $page = $this->createPage();
 
-        foreach ([$firstContent, $secondContent] as $content) {
+        foreach ($contents as $content) {
             /** @var ContentConfigurationInterface $contentConfiguration */
             $contentConfiguration = new ContentConfiguration();
             $contentConfiguration->setType('textarea');

--- a/tests/Behat/Context/Ui/Admin/ContentCollectionContext.php
+++ b/tests/Behat/Context/Ui/Admin/ContentCollectionContext.php
@@ -208,22 +208,6 @@ class ContentCollectionContext implements Context
     }
 
     /**
-     * @When I move the :ordinal content element up
-     */
-    public function iMoveTheContentElementUp(string $ordinal): void
-    {
-        $this->contentElementsCollectionElement->moveContentElementUp($this->parseOrdinal($ordinal));
-    }
-
-    /**
-     * @When I move the :ordinal content element down
-     */
-    public function iMoveTheContentElementDown(string $ordinal): void
-    {
-        $this->contentElementsCollectionElement->moveContentElementDown($this->parseOrdinal($ordinal));
-    }
-
-    /**
      * @Then the :ordinal content element should be a :type element
      */
     public function theContentElementAtPositionShouldBeOfType(string $ordinal, string $type): void
@@ -262,6 +246,44 @@ class ContentCollectionContext implements Context
         Assert::true(
             $this->contentElementsCollectionElement->isContentElementMoveDownButtonDisabled($this->parseOrdinal($ordinal)),
         );
+    }
+
+    /**
+     * @When I insert a textarea content element after the :ordinal content element
+     */
+    public function iInsertATextareaContentElementAfterTheContentElement(string $ordinal): void
+    {
+        $this->contentElementsCollectionElement->insertContentElementAfterPosition(
+            TextareaContentElementType::TYPE,
+            $this->parseOrdinal($ordinal),
+        );
+    }
+
+    /**
+     * @When I insert a textarea content element before the :ordinal content element
+     */
+    public function iInsertATextareaContentElementBeforeTheContentElement(string $ordinal): void
+    {
+        $this->contentElementsCollectionElement->insertContentElementBeforePosition(
+            TextareaContentElementType::TYPE,
+            $this->parseOrdinal($ordinal),
+        );
+    }
+
+    /**
+     * @When I move the :ordinal content element up
+     */
+    public function iMoveTheContentElementUp(string $ordinal): void
+    {
+        $this->contentElementsCollectionElement->moveContentElementUp($this->parseOrdinal($ordinal));
+    }
+
+    /**
+     * @When I move the :ordinal content element down
+     */
+    public function iMoveTheContentElementDown(string $ordinal): void
+    {
+        $this->contentElementsCollectionElement->moveContentElementDown($this->parseOrdinal($ordinal));
     }
 
     private function parseOrdinal(string $ordinal): int

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
@@ -157,16 +157,30 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
         $this->waitForFormUpdate();
     }
 
+    public function insertContentElementAfterPosition(string $type, int $afterPosition): void
+    {
+        $this->insertContentElementAtDividerIndex($type, $afterPosition);
+    }
+
+    public function insertContentElementBeforePosition(string $type, int $beforePosition): void
+    {
+        $this->insertContentElementAtDividerIndex($type, $beforePosition - 1);
+    }
+
     public function moveContentElementUp(int $position): void
     {
         $button = $this->getSortButton($position, 'up');
         $button->click();
+
+        $this->waitForFormUpdate();
     }
 
     public function moveContentElementDown(int $position): void
     {
         $button = $this->getSortButton($position, 'down');
         $button->click();
+
+        $this->waitForFormUpdate();
     }
 
     public function getContentElementTypeAtPosition(int $position): string
@@ -176,7 +190,6 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
 
         return $selectedOption->getText();
     }
-
     public function getContentElementContentAtPosition(int $position): string
     {
         $element = $this->getContentElementAtPosition($position);
@@ -208,6 +221,24 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
     public function isContentElementMoveDownButtonDisabled(int $position): bool
     {
         return $this->getSortButton($position, 'down')->hasAttribute('disabled');
+    }
+
+    private function insertContentElementAtDividerIndex(string $type, int $dividerIndex): void
+    {
+        $container = $this->getElement('elements_container', ['%locale%' => $this->defaultLocaleCode]);
+        $dividers = $container->findAll('css', '[data-test-insert-element-divider]');
+
+        Assert::keyExists($dividers, $dividerIndex, sprintf('No insert element divider at index %d.', $dividerIndex));
+
+        $toggleButton = $dividers[$dividerIndex]->find('css', '[data-bs-toggle="dropdown"]');
+        Assert::isInstanceOf($toggleButton, NodeElement::class, 'Dropdown toggle not found in insert element divider.');
+        $toggleButton->click();
+
+        $insertButton = $dividers[$dividerIndex]->find('css', sprintf('[data-test-insert-%s]', $type));
+        Assert::isInstanceOf($insertButton, NodeElement::class, sprintf('Insert button for type "%s" not found in divider.', $type));
+        $insertButton->click();
+
+        $this->waitForFormUpdate();
     }
 
     private function getSortButton(int $position, string $direction): NodeElement

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
@@ -190,6 +190,7 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
 
         return $selectedOption->getText();
     }
+
     public function getContentElementContentAtPosition(int $position): string
     {
         $element = $this->getContentElementAtPosition($position);

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElementInterface.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElementInterface.php
@@ -34,6 +34,10 @@ interface ContentElementsCollectionElementInterface
 
     public function removeContentElement(string $type): void;
 
+    public function insertContentElementAfterPosition(string $type, int $afterPosition): void;
+
+    public function insertContentElementBeforePosition(string $type, int $beforePosition): void;
+
     public function moveContentElementUp(int $position): void;
 
     public function moveContentElementDown(int $position): void;

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -1,5 +1,6 @@
 sylius_cms:
     ui:
+        add_element: Element hinzufügen
         blocks: Blöcke
         block: Block
         pages: Seiten


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #100 
| License         | MIT

This PR adds the feature to add new content elements between existing ones.

<img width="1314" height="957" alt="image" src="https://github.com/user-attachments/assets/b2f01e97-12c3-4125-9011-aef2f6baa790" />

### Why keys are preserved in `moveCollectionItem` (73-74)

Swap the two values while both rows keep their original keys. Giving a moved row a new key makes it look like a brand-new element to Symfony's `CollectionType`, which only ever appends unknown keys to the end of its children (see the note in `insertCollectionItem`). The row would therefore jump to the bottom of the collection instead of moving one position, and every subsequent move would operate on an order that no longer matches what is rendered.

Keeping the keys is safe for the stateful WYSIWYG widgets because `ContentElementConfigurationType` includes a signature of the element's content in the configuration container's DOM ID. When the content at a position changes, so does that ID, causing the Live Component to replace the entire subtree instead of morphing the widget in place.

### Why keys are replaced in `insertCollectionItem` (128-129)

Symfony's `CollectionType` (via `ResizeFormListener`) never reorders existing form children. It only appends keys that it does not have yet, always at the end of its internal list, regardless of where that key appears in the submitted array.

Giving only the new row a fresh key is therefore not enough to place it in the middle of the collection: the form would still render it last. Every row from the insertion point onward must look "new" so that Symfony drops and re-appends that entire tail in a single pass, in the order we submit it, placing it immediately after the untouched prefix.

Rows strictly before the insertion point keep their original key and DOM node untouched.
