### PR TITLE
[BUGFIX][1.2] Fix for moving element

### DIFF
--- a/features/admin/page/sorting_content_elements_on_page.feature
+++ b/features/admin/page/sorting_content_elements_on_page.feature
@@ -33,6 +33,33 @@ Feature: Sorting content elements on a page
         And the 2nd content element should be a "Heading" element
 
     @ui @javascript
+    Scenario: Reordering keeps textarea contents at their new positions
+        When I go to the create page page
+        And I fill the code with "sort-test-page"
+        And I fill the name with "Sort Test Page"
+        And I fill the slug with "sort-test-page"
+        And I add a textarea content element with "First textarea content" content
+        And I add a textarea content element with "Second textarea content" content
+        When I move the 2nd content element up
+        Then the 1st content element should be a "Textarea" element
+        And the 2nd content element should be a "Textarea" element
+        And the 1st content element should contain "Second textarea content"
+        And the 2nd content element should contain "First textarea content"
+
+    @ui @javascript
+    Scenario: Reordering keeps the selected media of adjacent autocomplete elements
+        Given there is an existing media with names "Image 1" and "Image 2"
+        When I go to the create page page
+        And I fill the code with "sort-test-page"
+        And I fill the name with "Sort Test Page"
+        And I fill the slug with "sort-test-page"
+        And I add a single media content element with name "Image 1"
+        And I add a single media content element with name "Image 2"
+        When I move the 2nd content element up
+        Then the 1st content element should contain "Image 2"
+        And the 2nd content element should contain "Image 1"
+
+    @ui @javascript
     Scenario: The first content element cannot be moved up
         When I go to the create page page
         And I fill the code with "sort-test-page"

--- a/src/Form/Type/ContentElements/ContentElementConfigurationType.php
+++ b/src/Form/Type/ContentElements/ContentElementConfigurationType.php
@@ -86,6 +86,15 @@ final class ContentElementConfigurationType extends AbstractResourceType
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['types'] = $options['types'];
+        $data = $form->getData();
+        $signature = '';
+
+        if ($data instanceof ContentConfigurationInterface) {
+            $value = sprintf('%s|%s', $data->getType(), json_encode($data->getConfiguration(), \JSON_THROW_ON_ERROR));
+            $signature = substr(md5($value), 0, 12);
+        }
+
+        $view->vars['content_signature'] = $signature;
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/Type/ContentElements/ContentElementConfigurationType.php
+++ b/src/Form/Type/ContentElements/ContentElementConfigurationType.php
@@ -90,7 +90,7 @@ final class ContentElementConfigurationType extends AbstractResourceType
         $signature = '';
 
         if ($data instanceof ContentConfigurationInterface) {
-            $value = sprintf('%s|%s', $data->getType(), json_encode($data->getConfiguration(), JSON_THROW_ON_ERROR));
+            $value = sprintf('%s|%s', $data->getType(), json_encode($data->getConfiguration(), \JSON_THROW_ON_ERROR));
             $signature = substr(md5($value), 0, 12);
         }
 

--- a/src/Form/Type/ContentElements/ContentElementConfigurationType.php
+++ b/src/Form/Type/ContentElements/ContentElementConfigurationType.php
@@ -90,7 +90,7 @@ final class ContentElementConfigurationType extends AbstractResourceType
         $signature = '';
 
         if ($data instanceof ContentConfigurationInterface) {
-            $value = sprintf('%s|%s', $data->getType(), json_encode($data->getConfiguration(), \JSON_THROW_ON_ERROR));
+            $value = sprintf('%s|%s', $data->getType(), json_encode($data->getConfiguration(), JSON_THROW_ON_ERROR));
             $signature = substr(md5($value), 0, 12);
         }
 

--- a/templates/admin/shared/component_elements/form_theme.html.twig
+++ b/templates/admin/shared/component_elements/form_theme.html.twig
@@ -15,7 +15,7 @@
         <div class="alert text-body d-flex align-items-center gap-4">
             <div class="flex-grow-1">
                 {{- form_row(form.type) -}}
-                <div>
+                <div id="{{ id }}_element_configuration_{{ form.vars.content_signature }}">
                     {{- form_row(form.configuration, {'label': false}) -}}
                 </div>
             </div>

--- a/tests/Behat/Context/Ui/Admin/ContentCollectionContext.php
+++ b/tests/Behat/Context/Ui/Admin/ContentCollectionContext.php
@@ -234,6 +234,18 @@ class ContentCollectionContext implements Context
     }
 
     /**
+     * @Then the :ordinal content element should contain :content
+     */
+    public function theContentElementAtPositionShouldContain(string $ordinal, string $content): void
+    {
+        Assert::contains(
+            $this->contentElementsCollectionElement->getContentElementContentAtPosition($this->parseOrdinal($ordinal)),
+            $content,
+            sprintf('Expected the %s content element to contain "%s", but it did not.', $ordinal, $content),
+        );
+    }
+
+    /**
      * @Then the move up button of the :ordinal content element should be disabled
      */
     public function theMoveUpButtonOfTheContentElementShouldBeDisabled(string $ordinal): void

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
@@ -171,13 +171,33 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
 
     public function getContentElementTypeAtPosition(int $position): string
     {
-        $elements = $this->getContentElements();
-        Assert::keyExists($elements, $position - 1, sprintf('No content element at position %d.', $position));
-
-        $selectedOption = $elements[$position - 1]->find('css', 'option[selected]');
+        $selectedOption = $this->getContentElementAtPosition($position)->find('css', 'option[selected]');
         Assert::notNull($selectedOption, sprintf('No selected type option found at position %d.', $position));
 
         return $selectedOption->getText();
+    }
+
+    public function getContentElementContentAtPosition(int $position): string
+    {
+        $element = $this->getContentElementAtPosition($position);
+        $autocomplete = $element->find('css', 'select[data-controller*="autocomplete"]');
+        if ($autocomplete instanceof NodeElement) {
+            $selectedOptions = $autocomplete->findAll('css', 'option[selected]');
+
+            return implode(', ', array_map(
+                static fn (NodeElement $option): string => trim($option->getText()),
+                $selectedOptions,
+            ));
+        }
+
+        $wysiwygInput = $element->find('css', 'input[type="hidden"][name$="[textarea]"]');
+        if ($wysiwygInput instanceof NodeElement) {
+            $value = $wysiwygInput->getValue();
+
+            return is_string($value) ? $value : '';
+        }
+
+        return trim($element->getText());
     }
 
     public function isContentElementMoveUpButtonDisabled(int $position): bool
@@ -192,13 +212,21 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
 
     private function getSortButton(int $position, string $direction): NodeElement
     {
-        $elements = $this->getContentElements();
-        Assert::keyExists($elements, $position - 1, sprintf('No content element at position %d.', $position));
-
-        $button = $elements[$position - 1]->find('css', sprintf('[data-live-direction-param="%s"]', $direction));
+        $button = $this->getContentElementAtPosition($position)->find(
+            'css',
+            sprintf('[data-live-direction-param="%s"]', $direction),
+        );
         Assert::notNull($button, sprintf('Sort %s button not found at position %d.', $direction, $position));
 
         return $button;
+    }
+
+    private function getContentElementAtPosition(int $position): NodeElement
+    {
+        $elements = $this->getContentElements();
+        Assert::keyExists($elements, $position - 1, sprintf('No content element at position %d.', $position));
+
+        return $elements[$position - 1];
     }
 
     protected function getDefinedElements(): array

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElementInterface.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElementInterface.php
@@ -40,6 +40,8 @@ interface ContentElementsCollectionElementInterface
 
     public function getContentElementTypeAtPosition(int $position): string;
 
+    public function getContentElementContentAtPosition(int $position): string;
+
     public function isContentElementMoveUpButtonDisabled(int $position): bool;
 
     public function isContentElementMoveDownButtonDisabled(int $position): bool;

--- a/tests/Unit/Form/Type/ContentElements/ContentElementConfigurationTypeTest.php
+++ b/tests/Unit/Form/Type/ContentElements/ContentElementConfigurationTypeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sylius CMS Plugin package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\CmsPlugin\Unit\Form\Type\ContentElements;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\CmsPlugin\Entity\ContentConfiguration;
+use Sylius\CmsPlugin\Entity\ContentConfigurationInterface;
+use Sylius\CmsPlugin\Form\Type\ContentElements\ContentElementConfigurationType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+final class ContentElementConfigurationTypeTest extends TestCase
+{
+    private ContentElementConfigurationType $type;
+
+    protected function setUp(): void
+    {
+        $this->type = new ContentElementConfigurationType(ContentConfiguration::class, [], []);
+    }
+
+    public function testItExposesAContentSignatureForTheElement(): void
+    {
+        $view = $this->buildViewFor('textarea', ['textarea' => '<p>Some content</p>']);
+
+        self::assertArrayHasKey('content_signature', $view->vars);
+        self::assertMatchesRegularExpression('/^[a-f0-9]{12}$/', $view->vars['content_signature']);
+    }
+
+    public function testTheSignatureIsStableForIdenticalContent(): void
+    {
+        $first = $this->buildViewFor('textarea', ['textarea' => '<p>Same content</p>']);
+        $second = $this->buildViewFor('textarea', ['textarea' => '<p>Same content</p>']);
+
+        self::assertSame($first->vars['content_signature'], $second->vars['content_signature']);
+    }
+
+    public function testTheSignatureChangesWhenTheContentChanges(): void
+    {
+        $first = $this->buildViewFor('textarea', ['textarea' => '<p>First</p>']);
+        $second = $this->buildViewFor('textarea', ['textarea' => '<p>Second</p>']);
+
+        self::assertNotSame($first->vars['content_signature'], $second->vars['content_signature']);
+    }
+
+    public function testTheSignatureChangesWhenTheTypeChanges(): void
+    {
+        $textarea = $this->buildViewFor('textarea', ['textarea' => 'value']);
+        $singleMedia = $this->buildViewFor('single_media', ['single_media' => 'value']);
+
+        self::assertNotSame($textarea->vars['content_signature'], $singleMedia->vars['content_signature']);
+    }
+
+    public function testTheSignatureIsEmptyWhenThereIsNoElementData(): void
+    {
+        $form = $this->createMock(FormInterface::class);
+        $form->method('getData')->willReturn(null);
+
+        $view = new FormView();
+        $this->type->buildView($view, $form, ['types' => []]);
+
+        self::assertSame('', $view->vars['content_signature']);
+    }
+
+    /** @param array<string, mixed> $configuration */
+    private function buildViewFor(string $type, array $configuration): FormView
+    {
+        $data = new ContentConfiguration();
+        $data->setType($type);
+        $data->setConfiguration($configuration);
+
+        $form = $this->createMock(FormInterface::class);
+        $form->method('getData')->willReturn($data);
+        self::assertInstanceOf(ContentConfigurationInterface::class, $data);
+
+        $view = new FormView();
+        $this->type->buildView($view, $form, ['types' => []]);
+
+        return $view;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        |yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #100, completion of this PR: https://github.com/Sylius/CmsPlugin/pull/159
| License         | MIT

There was 2 bugs (see video).

[Bug-Capture-aF9s-8IPDna317y3fe3JbM51kjmGifKiO3w0GohwWQs-.webm](https://github.com/user-attachments/assets/942640ca-4e28-4b12-92ba-f2d790c70107)
[Bug-Capture-G9h7N-adIeRdn-FVFc9nkbAbtD-CIvOUHydfaq-EoSSF.webm](https://github.com/user-attachments/assets/9a299003-060c-4dd7-90ce-79a263f62136)

**Problem:**
Reordering content elements works by swapping values between fixed positions in the collection on the server side, after which the page is refreshed by Symfony UX LiveComponent, which patches the DOM in place.

Whenever the content/type at a given position changed, the morphing tried to turn one element's widget into another's within the same DOM node.

**Fix**
Append a signature of the element's content to the config container's id. As a result, when the content at a position changes (reorder), the id changes too - LiveComponent replaces the whole subtree instead of morphing it in place - the widget is recreated from the correct, server-rendered value. Works the same for trix and quill, with no JS changes.
