### PR TITLE
[FIX][1.2] Improve behat tests stability

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,7 +133,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Behat logs - Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ matrix.database }}"
+                    name: "Behat logs - Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ env.DB_TYPE }}-${{ env.DB_VERSION }}"
                     path: etc/build/
                     if-no-files-found: ignore
                     compression-level: 6

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
@@ -150,13 +150,15 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
 
     public function removeContentElement(string $type): void
     {
+        $countBefore = $this->countContentElementRows();
+
         $element = $this->getContentElementByTypeLabel($type);
 
         $element->find('css', '[data-test-delete-action]')?->click();
 
         $this->waitForFormUpdate();
 
-        $this->getDocument()->waitFor(5, fn (): bool => !$this->hasContentElement($type));
+        $this->getDocument()->waitFor(5, fn (): bool => $this->countContentElementRows() < $countBefore);
     }
 
     public function moveContentElementUp(int $position): void
@@ -299,6 +301,13 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
         Assert::notEmpty($elements, 'Content elements not found.');
 
         return $elements;
+    }
+
+    protected function countContentElementRows(): int
+    {
+        $container = $this->getElement('elements_container', ['%locale%' => $this->defaultLocaleCode]);
+
+        return count($container->findAll('css', '[data-test-entry-row]'));
     }
 
     protected function isSimpleContent(string $type): bool

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
@@ -155,6 +155,8 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
         $element->find('css', '[data-test-delete-action]')?->click();
 
         $this->waitForFormUpdate();
+
+        $this->getDocument()->waitFor(5, fn (): bool => !$this->hasContentElement($type));
     }
 
     public function moveContentElementUp(int $position): void

--- a/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
+++ b/tests/Behat/Element/Admin/ContentElementsCollectionElement.php
@@ -159,6 +159,37 @@ class ContentElementsCollectionElement extends FormElement implements ContentEle
         $this->waitForFormUpdate();
 
         $this->getDocument()->waitFor(5, fn (): bool => $this->countContentElementRows() < $countBefore);
+
+        $this->dumpDiagnostics(sprintf('after-delete-%s', $type));
+    }
+
+    /** TEMPORARY diagnostics helper - writes the collection state to the CI-uploaded etc/build dir. */
+    public function dumpDiagnostics(string $tag): void
+    {
+        try {
+            $dir = getcwd() . '/etc/build';
+            if (!is_dir($dir)) {
+                @mkdir($dir, 0o777, true);
+            }
+
+            $rows = [];
+            $container = $this->getElement('elements_container', ['%locale%' => $this->defaultLocaleCode]);
+            foreach ($container->findAll('css', '[data-test-entry-row]') as $row) {
+                $selected = $row->find('css', 'option[selected]');
+                $rows[] = null !== $selected ? $selected->getText() : '(no-selected-type)';
+            }
+
+            $slug = preg_replace('/[^a-z0-9._-]+/i', '_', $tag);
+            file_put_contents(
+                $dir . '/diag-content-elements.log',
+                sprintf("tag=%s rowCount=%d types=[%s]\n", $tag, count($rows), implode(', ', $rows)),
+                \FILE_APPEND,
+            );
+            file_put_contents(sprintf('%s/diag-%s-container.html', $dir, $slug), $container->getOuterHtml());
+            file_put_contents(sprintf('%s/diag-%s-page.html', $dir, $slug), $this->getDocument()->getContent());
+        } catch (\Throwable $throwable) {
+            file_put_contents(getcwd() . '/etc/build/diag-content-elements.log', sprintf("tag=%s ERROR=%s\n", $tag, $throwable->getMessage()), \FILE_APPEND);
+        }
     }
 
     public function moveContentElementUp(int $position): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Deleting a content element is a Symfony UX LiveComponent round-trip, but the test only waited for the busy attribute to clear, so under CI load the next "update" step submitted the form before the element was actually removed - posting a stale, invalid element and getting an HTTP 422 with no flash message. The fix makes removeContentElement() wait until the element is really gone from the DOM before continuing, eliminating the race.

Also fixed the artifact creation problem.