### PR TITLE
Remove empty content elements in pre submit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,7 +133,7 @@ jobs:
                 uses: actions/upload-artifact@v4
                 if: failure()
                 with:
-                    name: "Behat logs - Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ matrix.database }}"
+                    name: "Behat logs - Sylius ${{ matrix.sylius }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, ${{ env.DB_TYPE }}-${{ env.DB_VERSION }}"
                     path: etc/build/
                     if-no-files-found: ignore
                     compression-level: 6

--- a/features/admin/page/adding_page.feature
+++ b/features/admin/page/adding_page.feature
@@ -10,7 +10,7 @@ Feature: Adding new page
 
     @ui
     Scenario: Adding page minimal data
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "page_with_title"
         And I fill the slug with "page_with_title"
         And I fill the name with "page_with_title"
@@ -19,7 +19,7 @@ Feature: Adding new page
 
     @ui
     Scenario: Adding page
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "top_5_outfits_for_this_summer"
         And I fill the slug with "top_5_outfits_for_this_summer"
         And I fill the name with "Top 5 outfits for this summer"
@@ -31,27 +31,27 @@ Feature: Adding new page
     @ui
     Scenario: Trying to add page with existing code
         Given there is an existing page with "terms" code
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "terms"
         And I try to add it
         Then I should be notified that there is already an existing page with provided code
 
     @ui
     Scenario: Adding new page with blank data
-        When I go to the create page page
+        When I go to the create page
         And I add it
         And I should be notified that "Code, Name, Slug" fields cannot be blank
 
     @ui
     Scenario: Trying to add a page with too short data
-        When I go to the create page page
+        When I go to the create page
         And I fill "Code, Name, Slug, Meta keywords, Meta description" fields with 1 character
         And I try to add it
         Then I should be notified that "Code, Name, Slug, Meta keywords, Meta description" fields are too short
 
     @ui
     Scenario: Trying to add a page with too long data
-        When I go to the create page page
+        When I go to the create page
         And I fill "Code, Name, Slug, Meta keywords, Meta description" fields with 6000 characters
         And I try to add it
         Then I should be notified that "Code, Name, Slug, Meta keywords, Meta description" fields are too long
@@ -59,7 +59,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with collections
         Given there are existing collections named "Blog" and "Homepage" with "page" type
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "best_day_ever"
         And I fill the name with "Best day ever"
         And I fill the slug with "Slug"
@@ -70,7 +70,7 @@ Feature: Adding new page
 
     @ui @javascript
     Scenario: Adding page with textarea content element
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -82,7 +82,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with single media content element
         Given there is an existing media with "image_1" code and name "Image 1"
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -94,7 +94,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with multiple media content element
         Given there is an existing media with names "Image 1" and "Image 2"
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -105,7 +105,7 @@ Feature: Adding new page
 
     @ui @javascript
     Scenario: Adding page with heading content element
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -117,7 +117,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with products carousel content element
         Given the store has "iPhone 8" and "iPhone X" products
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -129,7 +129,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with products carousel by taxon content element
         Given the store has "Smartphones" taxonomy
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -141,7 +141,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with products grid content element
         Given the store has "iPhone 8" and "iPhone X" products
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -153,7 +153,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with products grid by taxon content element
         Given the store has "Smartphones" taxonomy
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -165,7 +165,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with taxons list content element
         Given the store classifies its products as "Smartphones" and "Laptops"
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -177,7 +177,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with two content elements
         Given there is an existing media with names "Image 1" and "Image 2"
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -191,7 +191,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with content template
         Given there is an existing content template named "Homepage" with "page" type that contains "Textarea, Single media" content elements
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"
@@ -204,7 +204,7 @@ Feature: Adding new page
 
     @ui
     Scenario: Adding page with with a custom template
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my-page"
         And I fill the name with "My page"
@@ -218,7 +218,7 @@ Feature: Adding new page
     @ui @javascript
     Scenario: Adding page with header and content template
         Given there is an existing content template named "Homepage" with "page" type that contains "Textarea, Heading" content elements
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "my_page"
         And I fill the slug with "my_page"
         And I fill the name with "My page"

--- a/features/admin/page/sorting_content_elements_on_page.feature
+++ b/features/admin/page/sorting_content_elements_on_page.feature
@@ -34,13 +34,13 @@ Feature: Sorting content elements on a page
 
     @ui @javascript
     Scenario: Reordering keeps textarea contents at their new positions
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "sort-test-page"
         And I fill the name with "Sort Test Page"
         And I fill the slug with "sort-test-page"
         And I add a textarea content element with "First textarea content" content
         And I add a textarea content element with "Second textarea content" content
-        When I move the 2nd content element up
+        And I move the 2nd content element up
         Then the 1st content element should be a "Textarea" element
         And the 2nd content element should be a "Textarea" element
         And the 1st content element should contain "Second textarea content"
@@ -55,7 +55,7 @@ Feature: Sorting content elements on a page
         And I fill the slug with "sort-test-page"
         And I add a single media content element with name "Image 1"
         And I add a single media content element with name "Image 2"
-        When I move the 2nd content element up
+        And I move the 2nd content element up
         Then the 1st content element should contain "Image 2"
         And the 2nd content element should contain "Image 1"
 

--- a/features/admin/page/sorting_content_elements_on_page.feature
+++ b/features/admin/page/sorting_content_elements_on_page.feature
@@ -10,7 +10,7 @@ Feature: Sorting content elements on a page
 
     @ui @javascript
     Scenario: Moving a content element down
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "sort-test-page"
         And I fill the name with "Sort Test Page"
         And I fill the slug with "sort-test-page"
@@ -22,7 +22,7 @@ Feature: Sorting content elements on a page
 
     @ui @javascript
     Scenario: Moving a content element up
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "sort-test-page"
         And I fill the name with "Sort Test Page"
         And I fill the slug with "sort-test-page"
@@ -49,7 +49,7 @@ Feature: Sorting content elements on a page
     @ui @javascript
     Scenario: Reordering keeps the selected media of adjacent autocomplete elements
         Given there is an existing media with names "Image 1" and "Image 2"
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "sort-test-page"
         And I fill the name with "Sort Test Page"
         And I fill the slug with "sort-test-page"
@@ -61,7 +61,7 @@ Feature: Sorting content elements on a page
 
     @ui @javascript
     Scenario: The first content element cannot be moved up
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "sort-test-page"
         And I fill the name with "Sort Test Page"
         And I fill the slug with "sort-test-page"
@@ -71,7 +71,7 @@ Feature: Sorting content elements on a page
 
     @ui @javascript
     Scenario: The last content element cannot be moved down
-        When I go to the create page page
+        When I go to the create page
         And I fill the code with "sort-test-page"
         And I fill the name with "Sort Test Page"
         And I fill the slug with "sort-test-page"

--- a/features/admin/wysiwyg/quill/manging_pages.feature
+++ b/features/admin/wysiwyg/quill/manging_pages.feature
@@ -9,11 +9,11 @@ Feature: Managing dynamic content on block page
 
     @ui @javascript
     Scenario: Adding page
-        When I go to the create page page
+        When I go to the create page
         Then I should see the Quill WYSIWYG editor initialized
 
     @ui @javascript
     Scenario: Updating page
         Given there is an existing page with "test_page" code
-        When I go to the update "test_page" page page
+        When I go to the update "test_page" page
         Then I should see the Quill WYSIWYG editor initialized

--- a/features/admin/wysiwyg/trix/manging_pages.feature
+++ b/features/admin/wysiwyg/trix/manging_pages.feature
@@ -9,12 +9,12 @@ Feature: Managing dynamic content on block page
 
     @ui @javascript
     Scenario: Adding page
-        When I go to the create page page
+        When I go to the create page
         Then I should see the Trix WYSIWYG editor initialized
 
     @ui @javascript
     Scenario: Updating page
         Given there is an existing page with "test_page" code
-        When I go to the update "test_page" page page
+        When I go to the update "test_page" page
         Then I should see the Trix WYSIWYG editor initialized
 

--- a/src/Form/Type/ContentConfigurationType.php
+++ b/src/Form/Type/ContentConfigurationType.php
@@ -17,6 +17,8 @@ use Sylius\Bundle\AdminBundle\Form\Type\AddButtonType;
 use Sylius\CmsPlugin\Form\Type\ContentElements\ContentElementConfigurationType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\UX\LiveComponent\Form\Type\LiveCollectionType;
@@ -65,6 +67,25 @@ final class ContentConfigurationType extends AbstractType
                 'required' => false,
             ])
         ;
+
+        $builder->get('contentElements')->addEventListener(
+            FormEvents::PRE_SUBMIT,
+            static function (FormEvent $event): void {
+                $data = $event->getData();
+                if (!is_array($data)) {
+                    return;
+                }
+
+                foreach ($data as $key => $element) {
+                    if (!is_array($element) || '' === ($element['type'] ?? '')) {
+                        unset($data[$key]);
+                    }
+                }
+
+                $event->setData($data);
+            },
+            1,
+        );
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/tests/Behat/Context/Ui/Admin/ContentCollectionContext.php
+++ b/tests/Behat/Context/Ui/Admin/ContentCollectionContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\CmsPlugin\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
 use Sylius\CmsPlugin\Form\Type\ContentElements\HeadingContentElementType;
 use Sylius\CmsPlugin\Form\Type\ContentElements\MultipleMediaContentElementType;
 use Sylius\CmsPlugin\Form\Type\ContentElements\ProductsCarouselByTaxonContentElementType;
@@ -233,9 +234,7 @@ class ContentCollectionContext implements Context
         );
     }
 
-    /**
-     * @Then the :ordinal content element should contain :content
-     */
+    #[Then('the :ordinal content element should contain :content')]
     public function theContentElementAtPositionShouldContain(string $ordinal, string $content): void
     {
         Assert::contains(

--- a/tests/Behat/Context/Ui/Admin/PageContext.php
+++ b/tests/Behat/Context/Ui/Admin/PageContext.php
@@ -49,9 +49,9 @@ final class PageContext implements Context
     }
 
     /**
-     * @When I go to the create page page
+     * @When I go to the create page
      */
-    public function iGoToTheCreatePagePage(): void
+    public function iGoToTheCreatePage(): void
     {
         $this->createPage->open();
     }
@@ -77,9 +77,9 @@ final class PageContext implements Context
     }
 
     /**
-     * @When I go to the update :code page page
+     * @When I go to the update :code page
      */
-    public function iGoToTheUpdatePagePage(string $code): void
+    public function iGoToTheUpdatePage(string $code): void
     {
         $page = $this->pageRepository->findOneBy(['code' => $code]);
 

--- a/tests/Behat/Context/Ui/Shop/PageContext.php
+++ b/tests/Behat/Context/Ui/Shop/PageContext.php
@@ -29,7 +29,7 @@ final class PageContext implements Context
     }
 
     /**
-     * @When I go to the :slug page
+     * @When I go to the ":slug" page
      */
     public function iGoToThePage(string $slug): void
     {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | completion of https://github.com/Sylius/CmsPlugin/pull/197
| License         | MIT

A live delete can leave a stray collection entry with an empty type behind (the DOM row is not always removed before the form is submitted). Such an entry has no resolvable configuration form, which would raise "This form should not contain extra fields". Drop these entries before the collection binds them, so deletion results in the intended, valid state.

This Pull Request also contains Behat improvements.