### PR TITLE
[Shop] Stop decoding entities in rendered content elements output

### DIFF
--- a/src/Renderer/ContentElementRendererStrategy.php
+++ b/src/Renderer/ContentElementRendererStrategy.php
@@ -42,7 +42,7 @@ final class ContentElementRendererStrategy implements ContentElementRendererStra
 
             foreach ($this->renderers as $renderer) {
                 if ($renderer->supports($contentElement)) {
-                    $content .= html_entity_decode($renderer->render($contentElement), \ENT_QUOTES);
+                    $content .= $renderer->render($contentElement);
 
                     break;
                 }

--- a/templates/shop/content_element/elements/multiple_media.html.twig
+++ b/templates/shop/content_element/elements/multiple_media.html.twig
@@ -1,5 +1,5 @@
 <div class="{{ content_element_base_class }}__multiple-media mb-3">
     {% for element in media %}
-        {{ element.renderedContent }}
+        {{ element.renderedContent|raw }}
     {% endfor %}
 </div>

--- a/templates/shop/content_element/elements/pages_collection.html.twig
+++ b/templates/shop/content_element/elements/pages_collection.html.twig
@@ -21,7 +21,7 @@
                             {% endif %}
                             {% if page.teaserContent %}
                                 <p class="card-text small text-secondary line-clamp mb-0" style="--line-clamp-number: 3;">
-                                    {{ page.teaserContent }}
+                                    {{ page.teaserContent|raw }}
                                 </p>
                                 <a href="{{ path('sylius_cms_shop_page_show', {'slug': page.slug}) }}" class="btn btn-light btn-sm mt-4">
                                     {{ 'sylius_cms.ui.read_more'|trans }}

--- a/templates/shop/content_element/elements/single_media.html.twig
+++ b/templates/shop/content_element/elements/single_media.html.twig
@@ -1,3 +1,3 @@
 <div class="{{ content_element_base_class }}__single-media mb-3">
-    {{ media.renderedContent }}
+    {{ media.renderedContent|raw }}
 </div>

--- a/templates/shop/content_element/elements/textarea.html.twig
+++ b/templates/shop/content_element/elements/textarea.html.twig
@@ -1,3 +1,3 @@
 <div class="{{ content_element_base_class }}__textarea mb-3">
-    {{ content }}
+    {{ content|raw }}
 </div>

--- a/tests/Unit/Renderer/ContentElementRendererStrategyTest.php
+++ b/tests/Unit/Renderer/ContentElementRendererStrategyTest.php
@@ -63,10 +63,32 @@ final class ContentElementRendererStrategyTest extends TestCase
         $contentElementMock->expects(self::once())->method('getLocale')->willReturn('en_US');
 
         $this->rendererMock->expects(self::once())->method('supports')->with($contentElementMock)->willReturn(true);
-        $this->rendererMock->expects(self::once())->method('render')->with($contentElementMock)->willReturn('&lt;p&gt;Hello World&lt;/p&gt;');
+        $this->rendererMock->expects(self::once())->method('render')->with($contentElementMock)->willReturn('<p>Hello World</p>');
         $this->contentParserMock->expects(self::once())->method('parse')->with('<p>Hello World</p>')->willReturn('<p>Hello World</p>');
 
         self::assertSame('<p>Hello World</p>', $this->contentElementRendererStrategy->render($pageMock));
+    }
+
+    public function testEmitsRenderedMarkupUntouched(): void
+    {
+        /** @var PageInterface&MockObject $pageMock */
+        $pageMock = $this->createMock(PageInterface::class);
+        /** @var ContentConfigurationInterface&MockObject $contentElementMock */
+        $contentElementMock = $this->createMock(ContentConfigurationInterface::class);
+
+        $pageMock->expects(self::once())->method('getContentElements')->willReturn(new ArrayCollection([$contentElementMock]));
+        $this->localeContextMock->expects(self::once())->method('getLocaleCode')->willReturn('en_US');
+        $contentElementMock->expects(self::once())->method('getLocale')->willReturn('en_US');
+
+        // Escaped text must stay escaped and attributes carrying entities must survive:
+        // decoding would unescape user input and cut the attribute at the first quote.
+        $markup = '<h2>Summer &lt;em&gt;offer&lt;/em&gt;</h2><div data-live-props-value="{&quot;product&quot;:1}"></div>';
+
+        $this->rendererMock->expects(self::once())->method('supports')->with($contentElementMock)->willReturn(true);
+        $this->rendererMock->expects(self::once())->method('render')->with($contentElementMock)->willReturn($markup);
+        $this->contentParserMock->expects(self::once())->method('parse')->with($markup)->willReturn($markup);
+
+        self::assertSame($markup, $this->contentElementRendererStrategy->render($pageMock));
     }
 
     public function testSkipsContentElementWithNonMatchingLocale(): void
@@ -99,7 +121,7 @@ final class ContentElementRendererStrategyTest extends TestCase
         $supportedElementMock->expects(self::once())->method('getLocale')->willReturn('en_US');
         $unsupportedElementMock->expects(self::once())->method('getLocale')->willReturn('en_US');
 
-        $this->rendererMock->expects(self::once())->method('render')->with($supportedElementMock)->willReturn('&lt;p&gt;Supported&lt;/p&gt;');
+        $this->rendererMock->expects(self::once())->method('render')->with($supportedElementMock)->willReturn('<p>Supported</p>');
         $this->rendererMock->expects(self::exactly(2))->method('supports')->willReturnOnConsecutiveCalls(true, false);
         $this->contentParserMock->expects(self::once())->method('parse')->with('<p>Supported</p>')->willReturn('<p>Supported</p>');
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #202
| License         | MIT

`ContentElementRendererStrategy` ran `html_entity_decode(ENT_QUOTES)` over the rendered HTML of every content element. The decode compensated Twig's auto-escaping for the four elements that emit pre-rendered HTML through a plain `{{ variable }}`, but it also inverted the escaping of every plain-text field (markup typed in a heading landed unescaped in the page) and corrupted attributes legitimately carrying entities (`data-live-props-value="{&quot;...` gets cut at the first decoded quote, killing Symfony UX Live Components inside products grids). Details and reproduction in #202.

This PR makes the strategy emit the rendered HTML untouched, and moves the unescaping where it belongs: a local `|raw` in the four templates whose variable holds pre-rendered HTML (`textarea`, `single_media`, `multiple_media`, `pages_collection`). For those four elements the output is unchanged: their escape-then-decode round trip was lossless, `|raw` just short-circuits it. Every other element now keeps Twig's escaping. Content that relied on the accidental unescaping (raw HTML typed into plain-text fields such as headings) now displays literally, which is the escaping contract those fields were meant to have.

Tests: the two strategy tests that asserted the decoding are updated, and a new one pins the pass-through behaviour (escaped user text stays escaped, entity-carrying attributes survive). Full `tests/Unit` suite green (183 tests, 457 assertions).

Deliberately out of scope: `Twig/Runtime/RenderContentRuntime` applies the same decode, but to stored content rather than template output, so it deserves its own analysis. Happy to follow up on it separately.