### PR TITLE
[Shop] Render the taxons list in the configured order and skip disabled taxons

### DIFF
--- a/src/Renderer/ContentElement/TaxonsListContentElementRenderer.php
+++ b/src/Renderer/ContentElement/TaxonsListContentElementRenderer.php
@@ -37,10 +37,8 @@ final class TaxonsListContentElementRenderer extends AbstractContentElement
         $taxonsCodes = $configuration['taxons_list']['taxons'];
 
         $taxonsByCode = [];
-        foreach ($this->taxonRepository->findBy(['code' => $taxonsCodes]) as $taxon) {
-            if ($taxon->isEnabled()) {
-                $taxonsByCode[(string) $taxon->getCode()] = $taxon;
-            }
+        foreach ($this->taxonRepository->findBy(['code' => $taxonsCodes, 'enabled' => true]) as $taxon) {
+            $taxonsByCode[(string) $taxon->getCode()] = $taxon;
         }
 
         $taxons = [];

--- a/src/Renderer/ContentElement/TaxonsListContentElementRenderer.php
+++ b/src/Renderer/ContentElement/TaxonsListContentElementRenderer.php
@@ -35,7 +35,20 @@ final class TaxonsListContentElementRenderer extends AbstractContentElement
     {
         $configuration = $contentConfiguration->getConfiguration();
         $taxonsCodes = $configuration['taxons_list']['taxons'];
-        $taxons = $this->taxonRepository->findBy(['code' => $taxonsCodes]);
+
+        $taxonsByCode = [];
+        foreach ($this->taxonRepository->findBy(['code' => $taxonsCodes]) as $taxon) {
+            if ($taxon->isEnabled()) {
+                $taxonsByCode[(string) $taxon->getCode()] = $taxon;
+            }
+        }
+
+        $taxons = [];
+        foreach ($taxonsCodes as $taxonCode) {
+            if (isset($taxonsByCode[$taxonCode])) {
+                $taxons[] = $taxonsByCode[$taxonCode];
+            }
+        }
 
         return $this->twig->render('@SyliusCmsPlugin/shop/content_element/index.html.twig', [
             'content_element' => $this->template,

--- a/tests/Unit/Renderer/ContentElement/TaxonsListContentElementRendererTest.php
+++ b/tests/Unit/Renderer/ContentElement/TaxonsListContentElementRendererTest.php
@@ -58,7 +58,7 @@ final class TaxonsListContentElementRendererTest extends TestCase
         self::assertFalse($this->taxonsListContentElementRenderer->supports($contentConfigurationMock));
     }
 
-    public function testRendersTaxonsListContentElement(): void
+    public function testRendersTaxonsListInTheConfiguredOrder(): void
     {
         /** @var Environment&MockObject $twigMock */
         $twigMock = $this->createMock(Environment::class);
@@ -66,18 +66,50 @@ final class TaxonsListContentElementRendererTest extends TestCase
         $contentConfigurationMock = $this->createMock(ContentConfigurationInterface::class);
         /** @var Taxon&MockObject $taxon1Mock */
         $taxon1Mock = $this->createMock(Taxon::class);
+        $taxon1Mock->method('getCode')->willReturn('code1');
+        $taxon1Mock->method('isEnabled')->willReturn(true);
         /** @var Taxon&MockObject $taxon2Mock */
         $taxon2Mock = $this->createMock(Taxon::class);
+        $taxon2Mock->method('getCode')->willReturn('code2');
+        $taxon2Mock->method('isEnabled')->willReturn(true);
+        $template = 'custom_template';
+        $this->taxonsListContentElementRenderer->setTemplate($template);
+        $this->taxonsListContentElementRenderer->setTwigEnvironment($twigMock);
+        $contentConfigurationMock->expects(self::once())->method('getConfiguration')->willReturn([
+            'taxons_list' => ['taxons' => ['code2', 'code1']],
+        ]);
+        $this->taxonRepositoryMock->expects(self::once())->method('findBy')->with(['code' => ['code2', 'code1']])->willReturn([$taxon1Mock, $taxon2Mock]);
+        $twigMock->expects(self::once())->method('render')->with('@SyliusCmsPlugin/shop/content_element/index.html.twig', [
+            'content_element' => $template,
+            'taxons' => [$taxon2Mock, $taxon1Mock],
+        ])->willReturn('rendered template');
+        self::assertSame('rendered template', $this->taxonsListContentElementRenderer->render($contentConfigurationMock));
+    }
+
+    public function testSkipsDisabledTaxons(): void
+    {
+        /** @var Environment&MockObject $twigMock */
+        $twigMock = $this->createMock(Environment::class);
+        /** @var ContentConfigurationInterface&MockObject $contentConfigurationMock */
+        $contentConfigurationMock = $this->createMock(ContentConfigurationInterface::class);
+        /** @var Taxon&MockObject $enabledTaxonMock */
+        $enabledTaxonMock = $this->createMock(Taxon::class);
+        $enabledTaxonMock->method('getCode')->willReturn('code1');
+        $enabledTaxonMock->method('isEnabled')->willReturn(true);
+        /** @var Taxon&MockObject $disabledTaxonMock */
+        $disabledTaxonMock = $this->createMock(Taxon::class);
+        $disabledTaxonMock->method('getCode')->willReturn('code2');
+        $disabledTaxonMock->method('isEnabled')->willReturn(false);
         $template = 'custom_template';
         $this->taxonsListContentElementRenderer->setTemplate($template);
         $this->taxonsListContentElementRenderer->setTwigEnvironment($twigMock);
         $contentConfigurationMock->expects(self::once())->method('getConfiguration')->willReturn([
             'taxons_list' => ['taxons' => ['code1', 'code2']],
         ]);
-        $this->taxonRepositoryMock->expects(self::once())->method('findBy')->with(['code' => ['code1', 'code2']])->willReturn([$taxon1Mock, $taxon2Mock]);
+        $this->taxonRepositoryMock->expects(self::once())->method('findBy')->with(['code' => ['code1', 'code2']])->willReturn([$enabledTaxonMock, $disabledTaxonMock]);
         $twigMock->expects(self::once())->method('render')->with('@SyliusCmsPlugin/shop/content_element/index.html.twig', [
             'content_element' => $template,
-            'taxons' => [$taxon1Mock, $taxon2Mock],
+            'taxons' => [$enabledTaxonMock],
         ])->willReturn('rendered template');
         self::assertSame('rendered template', $this->taxonsListContentElementRenderer->render($contentConfigurationMock));
     }

--- a/tests/Unit/Renderer/ContentElement/TaxonsListContentElementRendererTest.php
+++ b/tests/Unit/Renderer/ContentElement/TaxonsListContentElementRendererTest.php
@@ -67,18 +67,16 @@ final class TaxonsListContentElementRendererTest extends TestCase
         /** @var Taxon&MockObject $taxon1Mock */
         $taxon1Mock = $this->createMock(Taxon::class);
         $taxon1Mock->method('getCode')->willReturn('code1');
-        $taxon1Mock->method('isEnabled')->willReturn(true);
         /** @var Taxon&MockObject $taxon2Mock */
         $taxon2Mock = $this->createMock(Taxon::class);
         $taxon2Mock->method('getCode')->willReturn('code2');
-        $taxon2Mock->method('isEnabled')->willReturn(true);
         $template = 'custom_template';
         $this->taxonsListContentElementRenderer->setTemplate($template);
         $this->taxonsListContentElementRenderer->setTwigEnvironment($twigMock);
         $contentConfigurationMock->expects(self::once())->method('getConfiguration')->willReturn([
             'taxons_list' => ['taxons' => ['code2', 'code1']],
         ]);
-        $this->taxonRepositoryMock->expects(self::once())->method('findBy')->with(['code' => ['code2', 'code1']])->willReturn([$taxon1Mock, $taxon2Mock]);
+        $this->taxonRepositoryMock->expects(self::once())->method('findBy')->with(['code' => ['code2', 'code1'], 'enabled' => true])->willReturn([$taxon1Mock, $taxon2Mock]);
         $twigMock->expects(self::once())->method('render')->with('@SyliusCmsPlugin/shop/content_element/index.html.twig', [
             'content_element' => $template,
             'taxons' => [$taxon2Mock, $taxon1Mock],
@@ -86,7 +84,7 @@ final class TaxonsListContentElementRendererTest extends TestCase
         self::assertSame('rendered template', $this->taxonsListContentElementRenderer->render($contentConfigurationMock));
     }
 
-    public function testSkipsDisabledTaxons(): void
+    public function testSkipsCodesThatResolveToNoEnabledTaxon(): void
     {
         /** @var Environment&MockObject $twigMock */
         $twigMock = $this->createMock(Environment::class);
@@ -95,18 +93,13 @@ final class TaxonsListContentElementRendererTest extends TestCase
         /** @var Taxon&MockObject $enabledTaxonMock */
         $enabledTaxonMock = $this->createMock(Taxon::class);
         $enabledTaxonMock->method('getCode')->willReturn('code1');
-        $enabledTaxonMock->method('isEnabled')->willReturn(true);
-        /** @var Taxon&MockObject $disabledTaxonMock */
-        $disabledTaxonMock = $this->createMock(Taxon::class);
-        $disabledTaxonMock->method('getCode')->willReturn('code2');
-        $disabledTaxonMock->method('isEnabled')->willReturn(false);
         $template = 'custom_template';
         $this->taxonsListContentElementRenderer->setTemplate($template);
         $this->taxonsListContentElementRenderer->setTwigEnvironment($twigMock);
         $contentConfigurationMock->expects(self::once())->method('getConfiguration')->willReturn([
             'taxons_list' => ['taxons' => ['code1', 'code2']],
         ]);
-        $this->taxonRepositoryMock->expects(self::once())->method('findBy')->with(['code' => ['code1', 'code2']])->willReturn([$enabledTaxonMock, $disabledTaxonMock]);
+        $this->taxonRepositoryMock->expects(self::once())->method('findBy')->with(['code' => ['code1', 'code2'], 'enabled' => true])->willReturn([$enabledTaxonMock]);
         $twigMock->expects(self::once())->method('render')->with('@SyliusCmsPlugin/shop/content_element/index.html.twig', [
             'content_element' => $template,
             'taxons' => [$enabledTaxonMock],


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #204
| License         | MIT

`TaxonsListContentElementRenderer` fetched the configured taxons with a bare `findBy(['code' => $codes])`: the order the contributor picked in the admin form was thrown away in favour of database order, and taxons disabled in the catalog kept being rendered while the rest of the shop hides them. Details and reproduction in #204.

This PR reorders the fetched taxons by the configured code list and filters out disabled ones. Codes that resolve to no enabled taxon are simply skipped, so a list keeps rendering when one of its taxons is disabled or deleted.

Tests: the render test now asserts the configured order is preserved (codes requested in reverse database order), and a new test covers the disabled-taxon filtering. Full `tests/Unit` suite green (183 tests).

Same family as #119 (disabled products in grids/carousels), which this PR does not touch.